### PR TITLE
Fix aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 Terraform Module that implements a CloudFront Distribution (CDN) for a custom origin (e.g. website) and [ships logs to a bucket](https://github.com/cloudposse/terraform-aws-log-storage). 
 
-If you need to accelerate an S3 bucket, we suggest using [`tf_cdn_s3`](https://github.com/cloudposse/terraform-cloudfront-s3-cdn) instead.
+If you need to accelerate an S3 bucket, we suggest using [`terraform-aws-cloudfront-s3-cdn`](https://github.com/cloudposse/terraform-aws-cloudfront-s3-cdn) instead.
 
 ## Usage
 
 ```hcl
 module "cdn" {
-  source             = "git::https://github.com/cloudposse/tf_cdn.git?ref=master"
+  source             = "git::https://github.com/cloudposse/terraform-aws-cloudfront-cdn.git?ref=master"
   namespace          = "${var.namespace}"
   stage              = "${var.stage}"
   name               = "${var.name}"

--- a/main.tf
+++ b/main.tf
@@ -48,7 +48,7 @@ resource "aws_cloudfront_distribution" "default" {
     prefix          = "${var.log_prefix}"
   }
 
-  aliases = "${var.aliases}"
+  aliases = ["${var.aliases}"]
 
   origin {
     domain_name = "${var.origin_domain_name}"


### PR DESCRIPTION
## what
* Explicitly pass variable as `list` despite already being `list`
* Update docs

## why
* My only guess is there's a bug in TF HCL validation whereby it doesn't detect the input is already a `list`