### PR TITLE
Disambiguate logs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ module "origin_label" {
   stage      = "${var.stage}"
   name       = "${var.name}"
   delimiter  = "${var.delimiter}"
-  attributes = "${compact(concat(var.attributes, list("origin")))}"
+  attributes = ["${compact(concat(var.attributes, list("origin")))}"]
   tags       = "${var.tags}"
 }
 
@@ -18,7 +18,7 @@ module "logs" {
   stage                    = "${var.stage}"
   name                     = "${var.name}"
   delimiter                = "${var.delimiter}"
-  attributes               = "${compact(concat(var.attributes, list("origin", "logs")))}"
+  attributes               = ["${compact(concat(var.attributes, list("origin", "logs")))}"]
   tags                     = "${var.tags}"
   prefix                   = "${var.log_prefix}"
   standard_transition_days = "${var.log_standard_transition_days}"

--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ module "origin_label" {
   stage      = "${var.stage}"
   name       = "${var.name}"
   delimiter  = "${var.delimiter}"
-  attributes = ["origin"]
+  attributes = "${compact(concat(var.attributes, list("origin")))}"
   tags       = "${var.tags}"
 }
 
@@ -18,7 +18,7 @@ module "logs" {
   stage                    = "${var.stage}"
   name                     = "${var.name}"
   delimiter                = "${var.delimiter}"
-  attributes               = ["logs"]
+  attributes               = "${compact(concat(var.attributes, list("origin", "logs")))}"
   tags                     = "${var.tags}"
   prefix                   = "${var.log_prefix}"
   standard_transition_days = "${var.log_standard_transition_days}"

--- a/main.tf
+++ b/main.tf
@@ -27,12 +27,13 @@ module "logs" {
 }
 
 module "distribution_label" {
-  source    = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.2.1"
-  namespace = "${var.namespace}"
-  stage     = "${var.stage}"
-  name      = "${var.name}"
-  delimiter = "${var.delimiter}"
-  tags      = "${var.tags}"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.2.1"
+  namespace  = "${var.namespace}"
+  stage      = "${var.stage}"
+  name       = "${var.name}"
+  attributes = "${var.attributes}"
+  delimiter  = "${var.delimiter}"
+  tags       = "${var.tags}"
 }
 
 resource "aws_cloudfront_distribution" "default" {

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,11 @@ variable "namespace" {}
 
 variable "stage" {}
 
+variable "attributes" {
+  type    = "list"
+  default = []
+}
+
 variable "tags" {
   default = {}
 }


### PR DESCRIPTION
## what
* Add support for `attributes` property (should have been there anyways)
* Disambiguate logs by adding `logs` attribute

## why
* Avoid collisions 