### PR TITLE
Add Support for `Vary` Headers for CloudFront

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ aws acm request-certificate --domain-name example.com --subject-alternative-name
 | `default_root_object`          | `index.html`                      | Object that CloudFront return when requests the root URL                                                                        | No       |
 | `enabled`                      | `true`                            | State of CloudFront                                                                                                             | No       |
 | `forward_cookies`              | `none`                            | Forward cookies to the origin that is associated with this cache behavior                                                       | No       |
+| `forward_headers`              | `[]`                              | Specify headers that you want CloudFront to vary upon for this cache behavior. Specify `*` to include all headers.   | No       |
 | `forward_query_string`         | `false`                           | Forward query strings to the origin that is associated with this cache behavior                                                 | No       |
 | `geo_restriction_locations`    | `[]`                              | List of country codes for which  CloudFront either to distribute content (whitelist) or not distribute your content (blacklist) | No       |
 | `geo_restriction_type`         | `none`                            | Method that use to restrict distribution of your content by country: `none`, `whitelist`, or `blacklist`                        | No       |

--- a/main.tf
+++ b/main.tf
@@ -82,6 +82,8 @@ resource "aws_cloudfront_distribution" "default" {
     compress         = "${var.compress}"
 
     forwarded_values {
+      headers = ["${var.forward_headers}"]
+
       query_string = "${var.forward_query_string}"
 
       cookies {

--- a/variables.tf
+++ b/variables.tf
@@ -126,6 +126,7 @@ variable "forward_query_string" {
 }
 
 variable "forward_headers" {
+  description = "Specifies the Headers, if any, that you want CloudFront to vary upon for this cache behavior. Specify `*` to include all headers."
   type    = "list"
   default = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -125,6 +125,11 @@ variable "forward_query_string" {
   default = "false"
 }
 
+variable "forward_headers" {
+  type    = "list"
+  default = []
+}
+
 variable "forward_cookies" {
   default = "none"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -127,8 +127,8 @@ variable "forward_query_string" {
 
 variable "forward_headers" {
   description = "Specifies the Headers, if any, that you want CloudFront to vary upon for this cache behavior. Specify `*` to include all headers."
-  type    = "list"
-  default = []
+  type        = "list"
+  default     = []
 }
 
 variable "forward_cookies" {


### PR DESCRIPTION
## What
* Added forward headers variable

## Why
* Forward headers required for caching