### PR TITLE
Add usage examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Compiled files
+*.tfstate
+*.tfstate.backup
+*.terraform.tfstate*
+
+# Module directory
+.terraform/
+.idea
+*.iml

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Basic usage:
 ```hcl
 module "cdn" {
   source             = "git::https://github.com/cloudposse/terraform-aws-cloudfront-cdn.git?ref=master"
-  namespace          = "cloudposse"
+  namespace          = "cp"
   stage              = "prod"
   name               = "app"
   aliases            = ["cloudposse.com", "www.cloudposse.com"]
@@ -46,15 +46,15 @@ aws acm request-certificate --domain-name example.com --subject-alternative-name
 | `aliases`                      | `[]`                              | List of aliases. CAUTION! Names MUSTN'T contain trailing `.`                                                                    | Yes      |
 | `custom_error_response`        | `[]`                              | List of one or more custom error response element maps                                                                          | No       |
 | `allowed_methods`              | `["*"]`                           | List of allowed methods (e.g. ` GET, PUT, POST, DELETE, HEAD`) for AWS CloudFront                                               | No       |
-| `cached_methods`               | `["GET", "HEAD"]`                 | List of cached methods (e.g. ` GET, PUT, POST, DELETE, HEAD`)                                                                   | No       |:
+| `cached_methods`               | `["GET", "HEAD"]`                 | List of cached methods (e.g. ` GET, PUT, POST, DELETE, HEAD`)                                                                   | No       |
 | `cache_behavior`               | `[]`                              | List of cache behaviors to implement                                                                                            | No       |
 | `comment`                      | `Managed by Terraform`            | Comment for the origin access identity                                                                                          | No       |
 | `compress`                     | `false`                           | Compress content for web requests that include Accept-Encoding: gzip in the request header                                      | No       |
 | `default_root_object`          | `index.html`                      | Object that CloudFront return when requests the root URL                                                                        | No       |
 | `enabled`                      | `true`                            | State of CloudFront                                                                                                             | No       |
 | `forward_cookies`              | `none`                            | Forward cookies to the origin that is associated with this cache behavior                                                       | No       |
-| `forward_cookies_whitelisted_names` | `[]`                         | List of forwarded cookies                                                                                                       | No       |:
-| `forward_headers`              | `[]`                              | Specify headers that you want CloudFront to vary upon for this cache behavior. Specify `*` to include all headers.   | No       |
+| `forward_cookies_whitelisted_names` | `[]`                         | List of forwarded cookies                                                                                                       | No       |
+| `forward_headers`              | `[]`                              | Specify headers that you want CloudFront to vary upon for this cache behavior. Specify `*` to include all headers.              | No       |
 | `forward_query_string`         | `false`                           | Forward query strings to the origin that is associated with this cache behavior                                                 | No       |
 | `geo_restriction_locations`    | `[]`                              | List of country codes for which  CloudFront either to distribute content (whitelist) or not distribute your content (blacklist) | No       |
 | `geo_restriction_type`         | `none`                            | Method that use to restrict distribution of your content by country: `none`, `whitelist`, or `blacklist`                        | No       |

--- a/README.md
+++ b/README.md
@@ -4,20 +4,27 @@ Terraform Module that implements a CloudFront Distribution (CDN) for a custom or
 
 If you need to accelerate an S3 bucket, we suggest using [`terraform-aws-cloudfront-s3-cdn`](https://github.com/cloudposse/terraform-aws-cloudfront-s3-cdn) instead.
 
+
 ## Usage
+
+Basic usage:
 
 ```hcl
 module "cdn" {
   source             = "git::https://github.com/cloudposse/terraform-aws-cloudfront-cdn.git?ref=master"
-  namespace          = "${var.namespace}"
-  stage              = "${var.stage}"
-  name               = "${var.name}"
-  aliases            = "${var.aliases}"
-  parent_zone_id     = "${var.parent_zone_id}"
-  parent_zone_name   = "${var.parent_zone_name}"
-  origin_domain_name = "${var.origin_domain_name}"
+  namespace          = "cloudposse"
+  stage              = "prod"
+  name               = "app"
+  aliases            = ["cloudposse.com", "www.cloudposse.com"]
+  parent_zone_name   = "cloudposse.com"
+  origin_domain_name = "origin.cloudposse.com"
 }
 ```
+
+
+Complete example of setting up CloudFront Distribution with Cache Behaviors for a WordPress site: [`examples/wordpress`](examples/wordpress/main.tf)
+
+
 ### Generating ACM Certificate
 
 Use the AWS cli to [request new ACM certifiates](http://docs.aws.amazon.com/acm/latest/userguide/gs-acm-request.html) (requires email validation)
@@ -26,7 +33,7 @@ aws acm request-certificate --domain-name example.com --subject-alternative-name
 ```
 
 
-## Variables
+## Inputs
 
 |  Name                          |  Default                          |  Description                                                                                                                    | Required |
 |:-------------------------------|:---------------------------------:|:--------------------------------------------------------------------------------------------------------------------------------|:--------:|
@@ -86,3 +93,10 @@ aws acm request-certificate --domain-name example.com --subject-alternative-name
 | `cf_status`                 | Current status of the distribution                                              |
 | `cf_aliases`                | Extra CNAMEs of AWS CloudFront                                                  |
 | `cf_origin_access_identity` | A shortcut to the full path for the origin access identity to use in CloudFront |
+
+
+## License
+
+[APACHE 2.0](LICENSE) © 2017 [Cloud Posse, LLC](https://cloudposse.com)
+
+See [`LICENSE`](LICENSE) for full details.

--- a/examples/wordpress/main.tf
+++ b/examples/wordpress/main.tf
@@ -1,0 +1,57 @@
+locals {
+  wp_nocache_behavior = {
+    viewer_protocol_policy = "redirect-to-https"
+    cached_methods         = ["GET", "HEAD"]
+    allowed_methods        = ["HEAD", "DELETE", "POST", "GET", "OPTIONS", "PUT", "PATCH"]
+    default_ttl            = 60
+    min_ttl                = 0
+    max_ttl                = 86400
+    compress               = "true"
+    target_origin_id       = "wordpress-cloudposse.com"
+
+    forwarded_values = [{
+      headers      = ["*"]
+      query_string = "true"
+
+      cookies = [{
+        forward = "all"
+      }]
+    }]
+  }
+}
+
+module "cdn" {
+  source     = "../../"
+  namespace  = "cp"
+  stage      = "prod"
+  name       = "wordpress"
+  attributes = ["cloudposse.com"]
+
+  aliases                           = ["cloudposse.com", "www.cloudposse.com"]
+  origin_domain_name                = "origin.cloudposse.com"
+  origin_protocol_policy            = "match-viewer"
+  viewer_protocol_policy            = "redirect-to-https"
+  parent_zone_name                  = "cloudposse.com"
+  default_root_object               = ""
+  acm_certificate_arn               = "xxxxxxxxxxxxxxxxxxx"
+  forward_cookies                   = "whitelist"
+  forward_cookies_whitelisted_names = ["comment_author_*", "comment_author_email_*", "comment_author_url_*", "wordpress_logged_in_*", "wordpress_test_cookie", "wp-settings-*"]
+  forward_headers                   = ["Host", "Origin", "Access-Control-Request-Headers", "Access-Control-Request-Method"]
+  forward_query_string              = "true"
+  default_ttl                       = 60
+  min_ttl                           = 0
+  max_ttl                           = 86400
+  compress                          = "true"
+  cached_methods                    = ["GET", "HEAD"]
+  allowed_methods                   = ["GET", "HEAD", "OPTIONS"]
+  price_class                       = "PriceClass_All"
+
+  cache_behavior = [
+    "${merge(local.wp_nocache_behavior, map("path_pattern", "wp-admin/*"))}",
+    "${merge(local.wp_nocache_behavior, map("path_pattern", "wp-login.php"))}",
+    "${merge(local.wp_nocache_behavior, map("path_pattern", "wp-signup.php"))}",
+    "${merge(local.wp_nocache_behavior, map("path_pattern", "wp-trackback.php"))}",
+    "${merge(local.wp_nocache_behavior, map("path_pattern", "wp-cron.php"))}",
+    "${merge(local.wp_nocache_behavior, map("path_pattern", "xmlrpc.php"))}",
+  ]
+}

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "origin_label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.2.1"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.1"
   namespace  = "${var.namespace}"
   stage      = "${var.stage}"
   name       = "${var.name}"
@@ -27,7 +27,7 @@ module "logs" {
 }
 
 module "distribution_label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.2.1"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.1"
   namespace  = "${var.namespace}"
   stage      = "${var.stage}"
   name       = "${var.name}"

--- a/variables.tf
+++ b/variables.tf
@@ -10,6 +10,7 @@ variable "attributes" {
 }
 
 variable "tags" {
+  type    = "map"
   default = {}
 }
 
@@ -137,6 +138,7 @@ variable "forward_cookies" {
 }
 
 variable "forward_cookies_whitelisted_names" {
+  type        = "list"
   description = "List of forwarded cookie names"
   default     = []
 }
@@ -193,6 +195,7 @@ variable "parent_zone_name" {
 }
 
 variable "cache_behavior" {
+  type        = "list"
   description = "List of cache behaviors to implement"
   default     = []
 }


### PR DESCRIPTION
## what
* Added a complete example of setting up CloudFront Distribution with Cache Behaviors for a WordPress site
* Updated `README`

## why
* To conform to community standard: https://www.terraform.io/docs/registry/modules/publish.html
