### PR TITLE
Add support for overriding viewer_minimum_protocol_version

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ aws acm request-certificate --domain-name example.com --subject-alternative-name
 | `default_ttl`                  | `60`                              | Default amount of time (in seconds) that an object is in a CloudFront cache                                                     | No       |
 | `max_ttl`                      | `31536000`                        | Maximum amount of time (in seconds) that an object is in a CloudFront cache                                                     | No       |
 | `price_class`                  | `PriceClass_100`                  | Price class for this distribution: `PriceClass_All`, `PriceClass_200`, `PriceClass_100`                                         | No       |
+| `viewer_minimum_protocol_version` | `TLSv1`                        | The minimum version of the SSL protocol that you want CloudFront to use for HTTPS connections.                                  | No       |
 | `viewer_protocol_policy`       | `redirect-to-https`               | Element to specify the protocol: `allow-all`, `https-only`, `redirect-to-https`                                                 | No       |
 | `origin_path`                  | ``                                | Element that causes CloudFront to request your content from a directory in your Amazon S3 bucket                                | No       |
 | `origin_domain_name`           | ``                                | The DNS domain name of your custom origin (e.g. website)                                                                        | Yes      |

--- a/main.tf
+++ b/main.tf
@@ -71,7 +71,7 @@ resource "aws_cloudfront_distribution" "default" {
   viewer_certificate {
     acm_certificate_arn            = "${var.acm_certificate_arn}"
     ssl_support_method             = "sni-only"
-    minimum_protocol_version       = "TLSv1"
+    minimum_protocol_version       = "${var.viewer_minimum_protocol_version}"
     cloudfront_default_certificate = true
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -147,6 +147,11 @@ variable "price_class" {
   default = "PriceClass_100"
 }
 
+variable "viewer_minimum_protocol_version" {
+  description = "(Optional) The minimum version of the SSL protocol that you want CloudFront to use for HTTPS connections."
+  default     = "TLSv1"
+}
+
 variable "viewer_protocol_policy" {
   description = "allow-all, redirect-to-https"
   default     = "redirect-to-https"


### PR DESCRIPTION
## what
* Add support for `viewer_minimum_protocol_version`

## why
* For certain use-cases it's desirable to enforce a newer version of TLS protocol since earlier ones have some security issues