### PR TITLE
Fix CloudFront default certificate

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -72,7 +72,7 @@ resource "aws_cloudfront_distribution" "default" {
     acm_certificate_arn            = "${var.acm_certificate_arn}"
     ssl_support_method             = "sni-only"
     minimum_protocol_version       = "${var.viewer_minimum_protocol_version}"
-    cloudfront_default_certificate = true
+    cloudfront_default_certificate = "${var.acm_certificate_arn == "" ? true : false}"
   }
 
   default_cache_behavior {


### PR DESCRIPTION
what
-
* Added conditional for cloudfront_default_certificate

why
-
* If acm_certificate_arn or iam_certificate_id is specified, cloudfront_default_certificate must be set to false, otherwise Terraform will try to recreate the certificate on each plan/apply. Copied from cloudposse/terraform-aws-cloudfront-s3-cdn#11