### PR TITLE
Cache Behavior fix and user experience enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ Available targets:
   lint                                Lint terraform code
 
 ```
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -93,12 +92,11 @@ Available targets:
 | aliases | List of aliases. CAUTION! Names MUSTN'T contain trailing `.` | list | `<list>` | no |
 | allowed_methods | List of allowed methods (e.g. ` GET, PUT, POST, DELETE, HEAD`) for AWS CloudFront | list | `<list>` | no |
 | attributes | Additional attributes (e.g. `policy` or `role`) | list | `<list>` | no |
-| cache_behavior | List of cache behaviors to implement | list | `<list>` | no |
 | cached_methods | List of cached methods (e.g. ` GET, PUT, POST, DELETE, HEAD`) | list | `<list>` | no |
 | comment | Comment for the origin access identity | string | `Managed by Terraform` | no |
 | compress | (Optional) Whether you want CloudFront to automatically compress content for web requests that include Accept-Encoding: gzip in the request header (default: false) | string | `false` | no |
 | custom_error_response | (Optional) - List of one or more custom error response element maps | list | `<list>` | no |
-| default_root_object | Object that CloudFront return when requests the root URL | string | `index.html` | no |
+| default_root_object | Object that CloudFront return when requests the root URL | string | `` | no |
 | default_ttl | Default amount of time (in seconds) that an object is in a CloudFront cache | string | `60` | no |
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | string | `-` | no |
 | dns_aliases_enabled | Set to false to prevent dns records for aliases from being created | string | `true` | no |
@@ -119,6 +117,7 @@ Available targets:
 | min_ttl | Minimum amount of time that you want objects to stay in CloudFront caches | string | `0` | no |
 | name | Name  (e.g. `bastion` or `db`) | string | - | yes |
 | namespace | Namespace (e.g. `cp` or `cloudposse`) | string | - | yes |
+| ordered_cache_behavior | List of cache behaviors to implement | list | `<list>` | no |
 | origin_domain_name | (Required) - The DNS domain name of your custom origin (e.g. website) | string | `` | no |
 | origin_http_port | (Required) - The HTTP port the custom origin listens on | string | `80` | no |
 | origin_https_port | (Required) - The HTTPS port the custom origin listens on | string | `443` | no |
@@ -233,7 +232,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyright
 
-Copyright © 2017-2018 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2019 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Available targets:
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | string | `-` | no |
 | dns_aliases_enabled | Set to false to prevent dns records for aliases from being created | string | `true` | no |
 | enabled | Set to false to prevent the module from creating any resources | string | `true` | no |
+| force_destroy_logs | Force delete the s3 bucket that contains the Cloudfront distribution logs when destroying the distribution | string | `false` | no |
 | forward_cookies | Specifies whether you want CloudFront to forward cookies to the origin. Valid options are all, none or whitelist | string | `none` | no |
 | forward_cookies_whitelisted_names | List of forwarded cookie names | list | `<list>` | no |
 | forward_headers | Specifies the Headers, if any, that you want CloudFront to vary upon for this cache behavior. Specify `*` to include all headers. | list | `<list>` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,4 +1,3 @@
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -7,12 +6,11 @@
 | aliases | List of aliases. CAUTION! Names MUSTN'T contain trailing `.` | list | `<list>` | no |
 | allowed_methods | List of allowed methods (e.g. ` GET, PUT, POST, DELETE, HEAD`) for AWS CloudFront | list | `<list>` | no |
 | attributes | Additional attributes (e.g. `policy` or `role`) | list | `<list>` | no |
-| cache_behavior | List of cache behaviors to implement | list | `<list>` | no |
 | cached_methods | List of cached methods (e.g. ` GET, PUT, POST, DELETE, HEAD`) | list | `<list>` | no |
 | comment | Comment for the origin access identity | string | `Managed by Terraform` | no |
 | compress | (Optional) Whether you want CloudFront to automatically compress content for web requests that include Accept-Encoding: gzip in the request header (default: false) | string | `false` | no |
 | custom_error_response | (Optional) - List of one or more custom error response element maps | list | `<list>` | no |
-| default_root_object | Object that CloudFront return when requests the root URL | string | `index.html` | no |
+| default_root_object | Object that CloudFront return when requests the root URL | string | `` | no |
 | default_ttl | Default amount of time (in seconds) that an object is in a CloudFront cache | string | `60` | no |
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | string | `-` | no |
 | dns_aliases_enabled | Set to false to prevent dns records for aliases from being created | string | `true` | no |
@@ -33,6 +31,7 @@
 | min_ttl | Minimum amount of time that you want objects to stay in CloudFront caches | string | `0` | no |
 | name | Name  (e.g. `bastion` or `db`) | string | - | yes |
 | namespace | Namespace (e.g. `cp` or `cloudposse`) | string | - | yes |
+| ordered_cache_behavior | List of cache behaviors to implement | list | `<list>` | no |
 | origin_domain_name | (Required) - The DNS domain name of your custom origin (e.g. website) | string | `` | no |
 | origin_http_port | (Required) - The HTTP port the custom origin listens on | string | `80` | no |
 | origin_https_port | (Required) - The HTTPS port the custom origin listens on | string | `443` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -15,6 +15,7 @@
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | string | `-` | no |
 | dns_aliases_enabled | Set to false to prevent dns records for aliases from being created | string | `true` | no |
 | enabled | Set to false to prevent the module from creating any resources | string | `true` | no |
+| force_destroy_logs | Force delete the s3 bucket that contains the Cloudfront distribution logs when destroying the distribution | string | `false` | no |
 | forward_cookies | Specifies whether you want CloudFront to forward cookies to the origin. Valid options are all, none or whitelist | string | `none` | no |
 | forward_cookies_whitelisted_names | List of forwarded cookie names | list | `<list>` | no |
 | forward_headers | Specifies the Headers, if any, that you want CloudFront to vary upon for this cache behavior. Specify `*` to include all headers. | list | `<list>` | no |

--- a/main.tf
+++ b/main.tf
@@ -24,6 +24,7 @@ module "logs" {
   standard_transition_days = "${var.log_standard_transition_days}"
   glacier_transition_days  = "${var.log_glacier_transition_days}"
   expiration_days          = "${var.log_expiration_days}"
+  force_destroy		   = "true"
 }
 
 module "distribution_label" {
@@ -98,7 +99,7 @@ resource "aws_cloudfront_distribution" "default" {
     max_ttl                = "${var.max_ttl}"
   }
 
-  cache_behavior = "${var.cache_behavior}"
+  ordered_cache_behavior = "${var.ordered_cache_behavior}"
 
   web_acl_id = "${var.web_acl_id}"
 

--- a/main.tf
+++ b/main.tf
@@ -24,7 +24,7 @@ module "logs" {
   standard_transition_days = "${var.log_standard_transition_days}"
   glacier_transition_days  = "${var.log_glacier_transition_days}"
   expiration_days          = "${var.log_expiration_days}"
-  force_destroy            = "true"
+  force_destroy            = "${var.force_destroy_logs}"
 }
 
 module "distribution_label" {

--- a/main.tf
+++ b/main.tf
@@ -24,7 +24,7 @@ module "logs" {
   standard_transition_days = "${var.log_standard_transition_days}"
   glacier_transition_days  = "${var.log_glacier_transition_days}"
   expiration_days          = "${var.log_expiration_days}"
-  force_destroy		   = "true"
+  force_destroy            = "true"
 }
 
 module "distribution_label" {

--- a/variables.tf
+++ b/variables.tf
@@ -241,3 +241,8 @@ variable "ordered_cache_behavior" {
   description = "List of cache behaviors to implement"
   default     = []
 }
+
+variable "force_destroy_logs" {
+  default     = "false"
+  description = "Force delete the s3 bucket that contains the Cloudfront distribution logs when destroying the distribution"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -114,7 +114,7 @@ variable "is_ipv6_enabled" {
 }
 
 variable "default_root_object" {
-  default     = "index.html"
+  default     = ""
   description = "Object that CloudFront return when requests the root URL"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -236,7 +236,7 @@ variable "parent_zone_name" {
   description = "Name of the hosted zone to contain this record (or specify `parent_zone_id`)"
 }
 
-variable "cache_behavior" {
+variable "ordered_cache_behavior" {
   type        = "list"
   description = "List of cache behaviors to implement"
   default     = []


### PR DESCRIPTION
A few updates in this PR:

1.  Fix to update "cache_behavior" to "ordered_cache_behavior" to match AWS deprecated terminology here.  Functionally this is the same just a rename

2.  Setting of default_root_object to an empty string by default, instead of "index.html".   Setting this to index.html will break expected behavior from some CMS frameworks and it's not always entirely obvious where the breakage is occurring.  A good example is WordPress - if the default document requested is index.html, WordPress will 404 on the home page.  Let the end user decide how to use this.

3.  Exposed the "force_destroy" option of the logs module, used inside this module, to the end user.  Otherwise, out-of-the-box this module will create a Cloudfront distribution, but you can't destroy it through any means without first cleaning up the S3 log bucket.  This might be desired behavior by some, but at least exposing the option, since we support it in the logs module already, is useful.