### PR TITLE
fix(output): Make sure "cf_aliases" won't fail if aliases not set

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -9,7 +9,7 @@ output "cf_arn" {
 }
 
 output "cf_aliases" {
-  value       = "${aws_cloudfront_distribution.default.aliases}"
+  value       = "${var.aliases}"
   description = "Extra CNAMEs of AWS CloudFront"
 }
 


### PR DESCRIPTION
When using `dns_aliases_enabled = "false"` and not setting `var.aliases`, terraform complains that attribute `aws_cloudfront_distribution.default.aliases` is not defined. 