### PR TITLE
Upgrading dns module - terraform-aws-route53-alias 0.2.5 -> 0.2.7

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -113,7 +113,7 @@ resource "aws_cloudfront_distribution" "default" {
 }
 
 module "dns" {
-  source           = "git::https://github.com/cloudposse/terraform-aws-route53-alias.git?ref=tags/0.2.5"
+  source           = "git::https://github.com/cloudposse/terraform-aws-route53-alias.git?ref=tags/0.2.7"
   enabled          = "${var.dns_aliases_enabled}"
   aliases          = "${var.aliases}"
   parent_zone_id   = "${var.parent_zone_id}"


### PR DESCRIPTION
Updating terraform-aws-route53-alias 0.2.5 -> 0.2.7
Per release notes: https://github.com/cloudposse/terraform-aws-route53-alias/releases/tag/0.2.6
0.2.6 and above has fixes interpolation for var.enabled. This will allow var.dns_aliases_enabled to be set to false without defining var.parent_zone_id and/or var.parent_zone_name.