### PR TITLE
Upgrade to 0.12

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ module "origin_label" {
   stage      = var.stage
   name       = var.name
   delimiter  = var.delimiter
-  attributes = [compact(concat(var.attributes, ["origin"]))]
+  attributes = compact(concat(var.attributes, ["origin"]))
   tags       = var.tags
 }
 
@@ -18,7 +18,7 @@ module "logs" {
   stage                    = var.stage
   name                     = var.name
   delimiter                = var.delimiter
-  attributes               = [compact(concat(var.attributes, ["origin", "logs"]))]
+  attributes               = compact(concat(var.attributes, ["origin", "logs"]))
   tags                     = var.tags
   lifecycle_prefix         = var.log_prefix
   standard_transition_days = var.log_standard_transition_days

--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,7 @@ resource "aws_cloudfront_origin_access_identity" "default" {
 }
 
 module "logs" {
-  source                   = "git::https://github.com/cloudposse/terraform-aws-s3-log-storage.git?ref=master"
+  source                   = "git::https://github.com/rverma-nikiai/terraform-aws-s3-log-storage.git?ref=master"
   namespace                = var.namespace
   stage                    = var.stage
   name                     = var.name
@@ -173,7 +173,7 @@ resource "aws_cloudfront_distribution" "default" {
 }
 
 module "dns" {
-  source           = "git::https://github.com/cloudposse/terraform-aws-route53-alias.git?ref=master"
+  source           = "git::https://github.com/rverma-nikiai/terraform-aws-route53-alias.git?ref=master"
   enabled          = var.dns_aliases_enabled
   aliases          = var.aliases
   parent_zone_id   = var.parent_zone_id

--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,7 @@ module "logs" {
   delimiter                = var.delimiter
   attributes               = [compact(concat(var.attributes, ["origin", "logs"]))]
   tags                     = var.tags
-  prefix                   = var.log_prefix
+  lifecycle_prefix         = var.log_prefix
   standard_transition_days = var.log_standard_transition_days
   glacier_transition_days  = var.log_glacier_transition_days
   expiration_days          = var.log_expiration_days

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "origin_label" {
-  source     = "git::https://github.com/rverma-nikiai/terraform-null-label.git?ref=master"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=master"
   namespace  = var.namespace
   stage      = var.stage
   name       = var.name
@@ -13,7 +13,7 @@ resource "aws_cloudfront_origin_access_identity" "default" {
 }
 
 module "logs" {
-  source                   = "git::https://github.com/rverma-nikiai/terraform-aws-s3-log-storage.git?ref=master"
+  source                   = "git::https://github.com/cloudposse/terraform-aws-s3-log-storage.git?ref=master"
   namespace                = var.namespace
   stage                    = var.stage
   name                     = var.name
@@ -27,7 +27,7 @@ module "logs" {
 }
 
 module "distribution_label" {
-  source     = "git::https://github.com/rverma-nikiai/terraform-null-label.git?ref=master"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=master"
   namespace  = var.namespace
   stage      = var.stage
   name       = var.name
@@ -173,7 +173,7 @@ resource "aws_cloudfront_distribution" "default" {
 }
 
 module "dns" {
-  source           = "git::https://github.com/rverma-nikiai/terraform-aws-route53-alias.git?ref=master"
+  source           = "git::https://github.com/cloudposse/terraform-aws-route53-alias.git?ref=master"
   enabled          = var.dns_aliases_enabled
   aliases          = var.aliases
   parent_zone_id   = var.parent_zone_id

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "origin_label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=master"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.13.0"
   namespace  = var.namespace
   stage      = var.stage
   name       = var.name
@@ -27,7 +27,7 @@ module "logs" {
 }
 
 module "distribution_label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=master"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.13.0"
   namespace  = var.namespace
   stage      = var.stage
   name       = var.name

--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,7 @@ resource "aws_cloudfront_origin_access_identity" "default" {
 }
 
 module "logs" {
-  source                   = "git::https://github.com/rverma-nikiai/terraform-aws-s3-log-storage.git?ref=master"
+  source                   = "git::https://github.com/cloudposse/terraform-aws-s3-log-storage.git?ref=tags/0.5.0"
   namespace                = var.namespace
   stage                    = var.stage
   name                     = var.name
@@ -52,7 +52,7 @@ resource "aws_cloudfront_distribution" "default" {
   aliases = var.aliases
 
   dynamic "custom_error_response" {
-    for_each = [var.custom_error_response]
+    for_each = var.custom_error_response
     content {
       # TF-UPGRADE-TODO: The automatic upgrade tool can't predict
       # which keys might be set in maps assigned here, so it has
@@ -173,7 +173,7 @@ resource "aws_cloudfront_distribution" "default" {
 }
 
 module "dns" {
-  source           = "git::https://github.com/rverma-nikiai/terraform-aws-route53-alias.git?ref=master"
+  source           = "git::https://github.com/cloudposse/terraform-aws-route53-alias.git?ref=tags/0.3.0"
   enabled          = var.dns_aliases_enabled
   aliases          = var.aliases
   parent_zone_id   = var.parent_zone_id
@@ -181,4 +181,3 @@ module "dns" {
   target_dns_name  = aws_cloudfront_distribution.default.domain_name
   target_zone_id   = aws_cloudfront_distribution.default.hosted_zone_id
 }
-

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "origin_label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.13.0"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.14.1"
   namespace  = var.namespace
   stage      = var.stage
   name       = var.name
@@ -27,7 +27,7 @@ module "logs" {
 }
 
 module "distribution_label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.13.0"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.14.1"
   namespace  = var.namespace
   stage      = var.stage
   name       = var.name

--- a/main.tf
+++ b/main.tf
@@ -1,123 +1,184 @@
 module "origin_label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.7"
-  namespace  = "${var.namespace}"
-  stage      = "${var.stage}"
-  name       = "${var.name}"
-  delimiter  = "${var.delimiter}"
-  attributes = ["${compact(concat(var.attributes, list("origin")))}"]
-  tags       = "${var.tags}"
+  source     = "git::https://github.com/rverma-nikiai/terraform-null-label.git?ref=master"
+  namespace  = var.namespace
+  stage      = var.stage
+  name       = var.name
+  delimiter  = var.delimiter
+  attributes = [compact(concat(var.attributes, ["origin"]))]
+  tags       = var.tags
 }
 
 resource "aws_cloudfront_origin_access_identity" "default" {
-  comment = "${module.distribution_label.id}"
+  comment = module.distribution_label.id
 }
 
 module "logs" {
-  source                   = "git::https://github.com/cloudposse/terraform-aws-log-storage.git?ref=tags/0.2.2"
-  namespace                = "${var.namespace}"
-  stage                    = "${var.stage}"
-  name                     = "${var.name}"
-  delimiter                = "${var.delimiter}"
-  attributes               = ["${compact(concat(var.attributes, list("origin", "logs")))}"]
-  tags                     = "${var.tags}"
-  prefix                   = "${var.log_prefix}"
-  standard_transition_days = "${var.log_standard_transition_days}"
-  glacier_transition_days  = "${var.log_glacier_transition_days}"
-  expiration_days          = "${var.log_expiration_days}"
+  source                   = "git::https://github.com/rverma-nikiai/terraform-aws-s3-log-storage.git?ref=master"
+  namespace                = var.namespace
+  stage                    = var.stage
+  name                     = var.name
+  delimiter                = var.delimiter
+  attributes               = [compact(concat(var.attributes, ["origin", "logs"]))]
+  tags                     = var.tags
+  prefix                   = var.log_prefix
+  standard_transition_days = var.log_standard_transition_days
+  glacier_transition_days  = var.log_glacier_transition_days
+  expiration_days          = var.log_expiration_days
 }
 
 module "distribution_label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.7"
-  namespace  = "${var.namespace}"
-  stage      = "${var.stage}"
-  name       = "${var.name}"
-  attributes = "${var.attributes}"
-  delimiter  = "${var.delimiter}"
-  tags       = "${var.tags}"
+  source     = "git::https://github.com/rverma-nikiai/terraform-null-label.git?ref=master"
+  namespace  = var.namespace
+  stage      = var.stage
+  name       = var.name
+  attributes = var.attributes
+  delimiter  = var.delimiter
+  tags       = var.tags
 }
 
 resource "aws_cloudfront_distribution" "default" {
-  enabled             = "${var.enabled}"
-  is_ipv6_enabled     = "${var.is_ipv6_enabled}"
-  comment             = "${var.comment}"
-  default_root_object = "${var.default_root_object}"
-  price_class         = "${var.price_class}"
+  enabled             = var.enabled
+  is_ipv6_enabled     = var.is_ipv6_enabled
+  comment             = var.comment
+  default_root_object = var.default_root_object
+  price_class         = var.price_class
 
-  logging_config = {
-    include_cookies = "${var.log_include_cookies}"
-    bucket          = "${module.logs.bucket_domain_name}"
-    prefix          = "${var.log_prefix}"
+  logging_config {
+    include_cookies = var.log_include_cookies
+    bucket          = module.logs.bucket_domain_name
+    prefix          = var.log_prefix
   }
 
-  aliases = ["${var.aliases}"]
+  aliases = var.aliases
 
-  custom_error_response = ["${var.custom_error_response}"]
+  dynamic "custom_error_response" {
+    for_each = [var.custom_error_response]
+    content {
+      # TF-UPGRADE-TODO: The automatic upgrade tool can't predict
+      # which keys might be set in maps assigned here, so it has
+      # produced a comprehensive set here. Consider simplifying
+      # this after confirming which keys can be set in practice.
+
+      error_caching_min_ttl = lookup(custom_error_response.value, "error_caching_min_ttl", null)
+      error_code            = custom_error_response.value.error_code
+      response_code         = lookup(custom_error_response.value, "response_code", null)
+      response_page_path    = lookup(custom_error_response.value, "response_page_path", null)
+    }
+  }
 
   origin {
-    domain_name = "${var.origin_domain_name}"
-    origin_id   = "${module.distribution_label.id}"
-    origin_path = "${var.origin_path}"
+    domain_name = var.origin_domain_name
+    origin_id   = module.distribution_label.id
+    origin_path = var.origin_path
 
     custom_origin_config {
-      http_port                = "${var.origin_http_port}"
-      https_port               = "${var.origin_https_port}"
-      origin_protocol_policy   = "${var.origin_protocol_policy}"
-      origin_ssl_protocols     = "${var.origin_ssl_protocols}"
-      origin_keepalive_timeout = "${var.origin_keepalive_timeout}"
-      origin_read_timeout      = "${var.origin_read_timeout}"
+      http_port                = var.origin_http_port
+      https_port               = var.origin_https_port
+      origin_protocol_policy   = var.origin_protocol_policy
+      origin_ssl_protocols     = var.origin_ssl_protocols
+      origin_keepalive_timeout = var.origin_keepalive_timeout
+      origin_read_timeout      = var.origin_read_timeout
     }
   }
 
   viewer_certificate {
-    acm_certificate_arn            = "${var.acm_certificate_arn}"
+    acm_certificate_arn            = var.acm_certificate_arn
     ssl_support_method             = "sni-only"
-    minimum_protocol_version       = "${var.viewer_minimum_protocol_version}"
-    cloudfront_default_certificate = "${var.acm_certificate_arn == "" ? true : false}"
+    minimum_protocol_version       = var.viewer_minimum_protocol_version
+    cloudfront_default_certificate = var.acm_certificate_arn == "" ? true : false
   }
 
   default_cache_behavior {
-    allowed_methods  = "${var.allowed_methods}"
-    cached_methods   = "${var.cached_methods}"
-    target_origin_id = "${module.distribution_label.id}"
-    compress         = "${var.compress}"
+    allowed_methods  = var.allowed_methods
+    cached_methods   = var.cached_methods
+    target_origin_id = module.distribution_label.id
+    compress         = var.compress
 
     forwarded_values {
-      headers = ["${var.forward_headers}"]
+      headers = var.forward_headers
 
-      query_string = "${var.forward_query_string}"
+      query_string = var.forward_query_string
 
       cookies {
-        forward           = "${var.forward_cookies}"
-        whitelisted_names = ["${var.forward_cookies_whitelisted_names}"]
+        forward           = var.forward_cookies
+        whitelisted_names = var.forward_cookies_whitelisted_names
       }
     }
 
-    viewer_protocol_policy = "${var.viewer_protocol_policy}"
-    default_ttl            = "${var.default_ttl}"
-    min_ttl                = "${var.min_ttl}"
-    max_ttl                = "${var.max_ttl}"
+    viewer_protocol_policy = var.viewer_protocol_policy
+    default_ttl            = var.default_ttl
+    min_ttl                = var.min_ttl
+    max_ttl                = var.max_ttl
   }
 
-  ordered_cache_behavior = "${var.cache_behavior}"
+  dynamic "ordered_cache_behavior" {
+    for_each = var.cache_behavior
+    content {
+      # TF-UPGRADE-TODO: The automatic upgrade tool can't predict
+      # which keys might be set in maps assigned here, so it has
+      # produced a comprehensive set here. Consider simplifying
+      # this after confirming which keys can be set in practice.
 
-  web_acl_id = "${var.web_acl_id}"
+      allowed_methods           = ordered_cache_behavior.value.allowed_methods
+      cached_methods            = ordered_cache_behavior.value.cached_methods
+      compress                  = lookup(ordered_cache_behavior.value, "compress", null)
+      default_ttl               = lookup(ordered_cache_behavior.value, "default_ttl", null)
+      field_level_encryption_id = lookup(ordered_cache_behavior.value, "field_level_encryption_id", null)
+      max_ttl                   = lookup(ordered_cache_behavior.value, "max_ttl", null)
+      min_ttl                   = lookup(ordered_cache_behavior.value, "min_ttl", null)
+      path_pattern              = ordered_cache_behavior.value.path_pattern
+      smooth_streaming          = lookup(ordered_cache_behavior.value, "smooth_streaming", null)
+      target_origin_id          = ordered_cache_behavior.value.target_origin_id
+      trusted_signers           = lookup(ordered_cache_behavior.value, "trusted_signers", null)
+      viewer_protocol_policy    = ordered_cache_behavior.value.viewer_protocol_policy
 
-  restrictions {
-    geo_restriction {
-      restriction_type = "${var.geo_restriction_type}"
-      locations        = "${var.geo_restriction_locations}"
+      dynamic "forwarded_values" {
+        for_each = lookup(ordered_cache_behavior.value, "forwarded_values", [])
+        content {
+          headers                 = lookup(forwarded_values.value, "headers", null)
+          query_string            = forwarded_values.value.query_string
+          query_string_cache_keys = lookup(forwarded_values.value, "query_string_cache_keys", null)
+
+          dynamic "cookies" {
+            for_each = lookup(forwarded_values.value, "cookies", [])
+            content {
+              forward           = cookies.value.forward
+              whitelisted_names = lookup(cookies.value, "whitelisted_names", null)
+            }
+          }
+        }
+      }
+
+      dynamic "lambda_function_association" {
+        for_each = lookup(ordered_cache_behavior.value, "lambda_function_association", [])
+        content {
+          event_type   = lambda_function_association.value.event_type
+          include_body = lookup(lambda_function_association.value, "include_body", null)
+          lambda_arn   = lambda_function_association.value.lambda_arn
+        }
+      }
     }
   }
 
-  tags = "${module.distribution_label.tags}"
+  web_acl_id = var.web_acl_id
+
+  restrictions {
+    geo_restriction {
+      restriction_type = var.geo_restriction_type
+      locations        = var.geo_restriction_locations
+    }
+  }
+
+  tags = module.distribution_label.tags
 }
 
 module "dns" {
-  source           = "git::https://github.com/cloudposse/terraform-aws-route53-alias.git?ref=tags/0.2.5"
-  enabled          = "${var.dns_aliases_enabled}"
-  aliases          = "${var.aliases}"
-  parent_zone_id   = "${var.parent_zone_id}"
-  parent_zone_name = "${var.parent_zone_name}"
-  target_dns_name  = "${aws_cloudfront_distribution.default.domain_name}"
-  target_zone_id   = "${aws_cloudfront_distribution.default.hosted_zone_id}"
+  source           = "git::https://github.com/rverma-nikiai/terraform-aws-route53-alias.git?ref=master"
+  enabled          = var.dns_aliases_enabled
+  aliases          = var.aliases
+  parent_zone_id   = var.parent_zone_id
+  parent_zone_name = var.parent_zone_name
+  target_dns_name  = aws_cloudfront_distribution.default.domain_name
+  target_zone_id   = aws_cloudfront_distribution.default.hosted_zone_id
 }
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,39 +1,40 @@
 output "cf_id" {
-  value       = "${aws_cloudfront_distribution.default.id}"
+  value       = aws_cloudfront_distribution.default.id
   description = "ID of AWS CloudFront distribution"
 }
 
 output "cf_arn" {
-  value       = "${aws_cloudfront_distribution.default.arn}"
+  value       = aws_cloudfront_distribution.default.arn
   description = "ID of AWS CloudFront distribution"
 }
 
 output "cf_aliases" {
-  value       = "${var.aliases}"
+  value       = var.aliases
   description = "Extra CNAMEs of AWS CloudFront"
 }
 
 output "cf_status" {
-  value       = "${aws_cloudfront_distribution.default.status}"
+  value       = aws_cloudfront_distribution.default.status
   description = "Current status of the distribution"
 }
 
 output "cf_domain_name" {
-  value       = "${aws_cloudfront_distribution.default.domain_name}"
+  value       = aws_cloudfront_distribution.default.domain_name
   description = "Domain name corresponding to the distribution"
 }
 
 output "cf_etag" {
-  value       = "${aws_cloudfront_distribution.default.etag}"
+  value       = aws_cloudfront_distribution.default.etag
   description = "Current version of the distribution's information"
 }
 
 output "cf_hosted_zone_id" {
-  value       = "${aws_cloudfront_distribution.default.hosted_zone_id}"
+  value       = aws_cloudfront_distribution.default.hosted_zone_id
   description = "CloudFront Route 53 zone ID"
 }
 
 output "cf_origin_access_identity" {
-  value       = "${aws_cloudfront_origin_access_identity.default.cloudfront_access_identity_path}"
+  value       = aws_cloudfront_origin_access_identity.default.cloudfront_access_identity_path
   description = "A shortcut to the full path for the origin access identity to use in CloudFront"
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -11,13 +11,13 @@ variable "stage" {
 }
 
 variable "attributes" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "Additional attributes (e.g. `policy` or `role`)"
 }
 
 variable "tags" {
-  type        = "map"
+  type        = map(string)
   default     = {}
   description = "Additional tags (e.g. `map('BusinessUnit','XYZ')`)"
 }
@@ -43,7 +43,7 @@ variable "acm_certificate_arn" {
 }
 
 variable "aliases" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "List of aliases. CAUTION! Names MUSTN'T contain trailing `.`"
 }
@@ -53,7 +53,7 @@ variable "custom_error_response" {
   # https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution.html#custom-error-response-arguments
   description = "(Optional) - List of one or more custom error response element maps"
 
-  type    = "list"
+  type    = list(string)
   default = []
 }
 
@@ -89,7 +89,7 @@ variable "origin_protocol_policy" {
 
 variable "origin_ssl_protocols" {
   description = "(Required) - The SSL/TLS protocols that you want CloudFront to use when communicating with your origin over HTTPS"
-  type        = "list"
+  type        = list(string)
   default     = ["TLSv1", "TLSv1.1", "TLSv1.2"]
 }
 
@@ -155,7 +155,7 @@ variable "forward_query_string" {
 
 variable "forward_headers" {
   description = "Specifies the Headers, if any, that you want CloudFront to vary upon for this cache behavior. Specify `*` to include all headers."
-  type        = "list"
+  type        = list(string)
   default     = []
 }
 
@@ -165,7 +165,7 @@ variable "forward_cookies" {
 }
 
 variable "forward_cookies_whitelisted_names" {
-  type        = "list"
+  type        = list(string)
   description = "List of forwarded cookie names"
   default     = []
 }
@@ -186,13 +186,13 @@ variable "viewer_protocol_policy" {
 }
 
 variable "allowed_methods" {
-  type        = "list"
+  type        = list(string)
   default     = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
   description = "List of allowed methods (e.g. ` GET, PUT, POST, DELETE, HEAD`) for AWS CloudFront"
 }
 
 variable "cached_methods" {
-  type        = "list"
+  type        = list(string)
   default     = ["GET", "HEAD"]
   description = "List of cached methods (e.g. ` GET, PUT, POST, DELETE, HEAD`)"
 }
@@ -219,7 +219,7 @@ variable "geo_restriction_type" {
 }
 
 variable "geo_restriction_locations" {
-  type = "list"
+  type = list(string)
 
   # e.g. ["US", "CA", "GB", "DE"]
   default     = []
@@ -237,7 +237,8 @@ variable "parent_zone_name" {
 }
 
 variable "cache_behavior" {
-  type        = "list"
+  type        = list(string)
   description = "An ordered list of cache behaviors resource for this distribution. List from top to bottom in order of precedence. The topmost cache behavior will have precedence 0."
   default     = []
 }
+

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
This is the remaining work to finish off rverma-nikiai fork in case. I submitted a PR to the upstream repo. Happy to close this and work through the existing PR if you prefer.

I was able to get it to successfully run by fixing 0.12 upgrade bug from wrapping var.custom_error_response around wrapping it in a list.

Also pinned modules to published upstream cloudposse versions with 0.12 support.

Thanks!
