### PR TITLE
Add code to allow specification of bucket.

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Available targets:
 | id\_length\_limit | Limit `id` to this many characters.<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
 | is\_ipv6\_enabled | State of CloudFront IPv6 | `bool` | `true` | no |
 | label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
+| log\_bucket\_fqdn | Optional fqdn of logging bucket, if not supplied a bucket will be generated. | `string` | `""` | no |
 | log\_expiration\_days | Number of days after which to expunge the objects | `number` | `90` | no |
 | log\_glacier\_transition\_days | Number of days after which to move the data to the glacier storage tier | `number` | `60` | no |
 | log\_include\_cookies | Include cookies in access logs | `bool` | `false` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -43,6 +43,7 @@
 | id\_length\_limit | Limit `id` to this many characters.<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
 | is\_ipv6\_enabled | State of CloudFront IPv6 | `bool` | `true` | no |
 | label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
+| log\_bucket\_fqdn | Optional fqdn of logging bucket, if not supplied a bucket will be generated. | `string` | `""` | no |
 | log\_expiration\_days | Number of days after which to expunge the objects | `number` | `90` | no |
 | log\_glacier\_transition\_days | Number of days after which to move the data to the glacier storage tier | `number` | `60` | no |
 | log\_include\_cookies | Include cookies in access logs | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -15,6 +15,7 @@ resource "aws_cloudfront_origin_access_identity" "default" {
 module "logs" {
   source = "git::https://github.com/cloudposse/terraform-aws-log-storage.git?ref=tags/0.14.0"
 
+  enabled                  = module.this.enabled && length(var.log_bucket_fqdn) == 0
   attributes               = compact(concat(module.this.attributes, ["origin", "logs"]))
   lifecycle_prefix         = var.log_prefix
   standard_transition_days = var.log_standard_transition_days
@@ -35,7 +36,7 @@ resource "aws_cloudfront_distribution" "default" {
 
   logging_config {
     include_cookies = var.log_include_cookies
-    bucket          = module.logs.bucket_domain_name
+    bucket          = length(var.log_bucket_fqdn) > 0 ? var.log_bucket_fqdn : module.logs.bucket_domain_name
     prefix          = var.log_prefix
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -127,6 +127,12 @@ variable "log_prefix" {
   description = "Path of logs in S3 bucket"
 }
 
+variable "log_bucket_fqdn" {
+  type        = string
+  default     = ""
+  description = "Optional fqdn of logging bucket, if not supplied a bucket will be generated."
+}
+
 variable "log_standard_transition_days" {
   type        = number
   description = "Number of days to persist in the standard storage tier before moving to the glacier tier"


### PR DESCRIPTION
## what
* Introduced variable to specify bucket to log to.

## why
* Allow centralised logging rather than log to the same account
* They allow the log bucket to be specified rather than created in the same account by default.

## references
* closes #42 

