### PR TITLE
added passing of ipv6_enabled for aaaa record creation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -155,6 +155,7 @@ module "dns" {
   parent_zone_name = var.parent_zone_name
   target_dns_name  = try(aws_cloudfront_distribution.default[0].domain_name, "")
   target_zone_id   = try(aws_cloudfront_distribution.default[0].hosted_zone_id, "")
+  ipv6_enabled     = var.is_ipv6_enabled
 
   context = module.this.context
 }


### PR DESCRIPTION
## what
* added `ipv6_enabled` option to Route53 alias module so it will create AAAA records in addition to A ones

## why
* AAAA were not being created

## references
* https://github.com/cloudposse/terraform-aws-cloudfront-s3-cdn/blob/master/main.tf#L349

