### PR TITLE
added option to disable logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Available targets:
 | log\_include\_cookies | Include cookies in access logs | `bool` | `false` | no |
 | log\_prefix | Path of logs in S3 bucket | `string` | `""` | no |
 | log\_standard\_transition\_days | Number of days to persist in the standard storage tier before moving to the glacier tier | `number` | `30` | no |
+| logging\_enabled | When true, access logs will be sent to a newly created s3 bucket | `bool` | `true` | no |
 | max\_ttl | Maximum amount of time (in seconds) that an object is in a CloudFront cache | `number` | `31536000` | no |
 | min\_ttl | Minimum amount of time that you want objects to stay in CloudFront caches | `number` | `0` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
@@ -200,6 +201,7 @@ Available targets:
 | cf\_id | ID of CloudFront distribution |
 | cf\_origin\_access\_identity | A shortcut to the full path for the origin access identity to use in CloudFront |
 | cf\_status | Current status of the distribution |
+| logs | Logs resource |
 
 <!-- markdownlint-restore -->
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -49,6 +49,7 @@
 | log\_include\_cookies | Include cookies in access logs | `bool` | `false` | no |
 | log\_prefix | Path of logs in S3 bucket | `string` | `""` | no |
 | log\_standard\_transition\_days | Number of days to persist in the standard storage tier before moving to the glacier tier | `number` | `30` | no |
+| logging\_enabled | When true, access logs will be sent to a newly created s3 bucket | `bool` | `true` | no |
 | max\_ttl | Maximum amount of time (in seconds) that an object is in a CloudFront cache | `number` | `31536000` | no |
 | min\_ttl | Minimum amount of time that you want objects to stay in CloudFront caches | `number` | `0` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
@@ -85,5 +86,6 @@
 | cf\_id | ID of CloudFront distribution |
 | cf\_origin\_access\_identity | A shortcut to the full path for the origin access identity to use in CloudFront |
 | cf\_status | Current status of the distribution |
+| logs | Logs resource |
 
 <!-- markdownlint-restore -->

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -99,6 +99,12 @@ variable "comment" {
   description = "Comment for the origin access identity"
 }
 
+variable "logging_enabled" {
+  type        = bool
+  default     = true
+  description = "When true, access logs will be sent to a newly created s3 bucket"
+}
+
 variable "log_include_cookies" {
   default     = "false"
   description = "Include cookies in access logs"

--- a/outputs.tf
+++ b/outputs.tf
@@ -37,3 +37,8 @@ output "cf_origin_access_identity" {
   value       = try(aws_cloudfront_origin_access_identity.default[0].cloudfront_access_identity_path, "")
   description = "A shortcut to the full path for the origin access identity to use in CloudFront"
 }
+
+output "logs" {
+  value       = module.logs
+  description = "Logs resource"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -115,6 +115,12 @@ variable "comment" {
   description = "Comment for the origin access identity"
 }
 
+variable "logging_enabled" {
+  type        = bool
+  default     = true
+  description = "When true, access logs will be sent to a newly created s3 bucket"
+}
+
 variable "log_include_cookies" {
   type        = bool
   default     = false


### PR DESCRIPTION
## what
* added `logging_disabled` options to disable CloudFront logging to S3

## why
* logging was enabled by default with no easy way of disabling

## references
* https://github.com/cloudposse/terraform-aws-cloudfront-s3-cdn/blob/master/main.tf#L151

