### PR TITLE
Allow specifiying `force_destroy` for s3-log-storage submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 
 **/.build-harness
 **/build-harness
+.terraform.lock.hcl

--- a/README.md
+++ b/README.md
@@ -158,6 +158,22 @@ Available targets:
 |------|---------|
 | aws | >= 2.0 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| dns | cloudposse/route53-alias/aws | 0.12.0 |
+| logs | cloudposse/s3-log-storage/aws | 0.20.0 |
+| origin_label | cloudposse/label/null | 0.24.1 |
+| this | cloudposse/label/null | 0.24.1 |
+
+## Resources
+
+| Name |
+|------|
+| [aws_cloudfront_distribution](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution) |
+| [aws_cloudfront_origin_access_identity](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_access_identity) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -193,6 +209,7 @@ Available targets:
 | label\_value\_case | The letter case of output label values (also used in `tags` and `id`).<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br>Default value: `lower`. | `string` | `null` | no |
 | log\_bucket\_fqdn | Optional fqdn of logging bucket, if not supplied a bucket will be generated. | `string` | `""` | no |
 | log\_expiration\_days | Number of days after which to expunge the objects | `number` | `90` | no |
+| log\_force\_destroy | Applies to log bucket created by this module only. If true, all objects will be deleted from the bucket on destroy, so that the bucket can be destroyed without error. These objects are not recoverable. | `bool` | `false` | no |
 | log\_glacier\_transition\_days | Number of days after which to move the data to the glacier storage tier | `number` | `60` | no |
 | log\_include\_cookies | Include cookies in access logs | `bool` | `false` | no |
 | log\_prefix | Path of logs in S3 bucket | `string` | `""` | no |
@@ -235,7 +252,6 @@ Available targets:
 | cf\_origin\_access\_identity | A shortcut to the full path for the origin access identity to use in CloudFront |
 | cf\_status | Current status of the distribution |
 | logs | Logs resource |
-
 <!-- markdownlint-restore -->
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -13,6 +13,22 @@
 |------|---------|
 | aws | >= 2.0 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| dns | cloudposse/route53-alias/aws | 0.12.0 |
+| logs | cloudposse/s3-log-storage/aws | 0.20.0 |
+| origin_label | cloudposse/label/null | 0.24.1 |
+| this | cloudposse/label/null | 0.24.1 |
+
+## Resources
+
+| Name |
+|------|
+| [aws_cloudfront_distribution](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution) |
+| [aws_cloudfront_origin_access_identity](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_access_identity) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -48,6 +64,7 @@
 | label\_value\_case | The letter case of output label values (also used in `tags` and `id`).<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br>Default value: `lower`. | `string` | `null` | no |
 | log\_bucket\_fqdn | Optional fqdn of logging bucket, if not supplied a bucket will be generated. | `string` | `""` | no |
 | log\_expiration\_days | Number of days after which to expunge the objects | `number` | `90` | no |
+| log\_force\_destroy | Applies to log bucket created by this module only. If true, all objects will be deleted from the bucket on destroy, so that the bucket can be destroyed without error. These objects are not recoverable. | `bool` | `false` | no |
 | log\_glacier\_transition\_days | Number of days after which to move the data to the glacier storage tier | `number` | `60` | no |
 | log\_include\_cookies | Include cookies in access logs | `bool` | `false` | no |
 | log\_prefix | Path of logs in S3 bucket | `string` | `""` | no |
@@ -90,5 +107,4 @@
 | cf\_origin\_access\_identity | A shortcut to the full path for the origin access identity to use in CloudFront |
 | cf\_status | Current status of the distribution |
 | logs | Logs resource |
-
 <!-- markdownlint-restore -->

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -2,12 +2,18 @@ provider "aws" {
   region = var.region
 }
 
+resource "random_id" "id" {
+  byte_length = 8
+}
+
 module "cdn" {
   source = "../../"
 
   aliases            = var.aliases
   origin_domain_name = var.origin_domain_name
   parent_zone_name   = var.parent_zone_name
+  attributes         = [random_id.id.hex]
+  log_force_destroy  = true
 
   context = module.this.context
 }

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -112,7 +112,7 @@ variable "comment" {
 variable "logging_enabled" {
   type        = bool
   default     = true
-  description = "When true, access logs will be sent to a newly created s3 bucket"
+  description = "When true, access logs will be sent to a newly created S3 bucket or bucket specified by log_bucket_fqdn"
 }
 
 variable "log_include_cookies" {

--- a/main.tf
+++ b/main.tf
@@ -23,6 +23,7 @@ module "logs" {
   standard_transition_days = var.log_standard_transition_days
   glacier_transition_days  = var.log_glacier_transition_days
   expiration_days          = var.log_expiration_days
+  force_destroy            = var.log_force_destroy
 
   context = module.this.context
 }

--- a/variables.tf
+++ b/variables.tf
@@ -149,6 +149,12 @@ variable "log_bucket_fqdn" {
   description = "Optional fqdn of logging bucket, if not supplied a bucket will be generated."
 }
 
+variable "log_force_destroy" {
+  type        = bool
+  description = "Applies to log bucket created by this module only. If true, all objects will be deleted from the bucket on destroy, so that the bucket can be destroyed without error. These objects are not recoverable."
+  default     = false
+}
+
 variable "log_standard_transition_days" {
   type        = number
   description = "Number of days to persist in the standard storage tier before moving to the glacier tier"


### PR DESCRIPTION
## what
* Allow specifying `force_destroy` for s3-log-storage submodule
* Add random id to module attributes to cause S3 log bucket to have a random name

## why
* Automated tests were failing due to duplicate names and non-empty buckets

## references
* None

