### PR TITLE
Adding origin shield variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,8 @@ Available targets:
 | <a name="input_origin_protocol_policy"></a> [origin\_protocol\_policy](#input\_origin\_protocol\_policy) | The origin protocol policy to apply to your origin. One of http-only, https-only, or match-viewer | `string` | `"match-viewer"` | no |
 | <a name="input_origin_read_timeout"></a> [origin\_read\_timeout](#input\_origin\_read\_timeout) | The Custom Read timeout, in seconds. By default, AWS enforces a limit of 60. But you can request an increase. | `number` | `60` | no |
 | <a name="input_origin_request_policy_id"></a> [origin\_request\_policy\_id](#input\_origin\_request\_policy\_id) | ID of the origin request policy attached to the cache behavior | `string` | `null` | no |
+| <a name="input_origin_shield_enabled"></a> [origin\_shield\_enabled](#input\_origin\_shield\_enabled) | Use the CloudFront Origin Shield | `bool` | `false` | no |
+| <a name="input_origin_shield_region"></a> [origin\_shield\_region](#input\_origin\_shield\_region) | The AWS Region for the Origin Shield. Example: us-east-1 | `string` | `"us-east-1"` | no |
 | <a name="input_origin_ssl_protocols"></a> [origin\_ssl\_protocols](#input\_origin\_ssl\_protocols) | The SSL/TLS protocols that you want CloudFront to use when communicating with your origin over HTTPS | `list(string)` | <pre>[<br>  "TLSv1",<br>  "TLSv1.1",<br>  "TLSv1.2"<br>]</pre> | no |
 | <a name="input_parent_zone_id"></a> [parent\_zone\_id](#input\_parent\_zone\_id) | ID of the hosted zone to contain this record (or specify `parent_zone_name`) | `string` | `""` | no |
 | <a name="input_parent_zone_name"></a> [parent\_zone\_name](#input\_parent\_zone\_name) | Name of the hosted zone to contain this record (or specify `parent_zone_id`) | `string` | `""` | no |
@@ -272,7 +274,6 @@ Like this project? Please give it a ★ on [our GitHub](https://github.com/cloud
 Are you using this project or any of our other projects? Consider [leaving a testimonial][testimonial]. =)
 
 
-
 ## Related Projects
 
 Check out these related projects.
@@ -282,6 +283,8 @@ Check out these related projects.
 - [terraform-aws-cloudtrail](https://github.com/cloudposse/terraform-aws-cloudtrail) - Terraform module to provision an AWS CloudTrail and an encrypted S3 bucket with versioning to store CloudTrail logs
 - [terraform-aws-s3-website](https://github.com/cloudposse/terraform-aws-s3-website) - Terraform module to provision S3-backed websites
 - [terraform-root-modules/aws/docs](https://github.com/cloudposse/terraform-root-modules/tree/master/aws/docs) - Reference implementation combining `terraform-aws-s3-website` with `terraform-aws-cdn`
+
+
 
 ## Help
 

--- a/README.md
+++ b/README.md
@@ -233,8 +233,7 @@ Available targets:
 | <a name="input_origin_protocol_policy"></a> [origin\_protocol\_policy](#input\_origin\_protocol\_policy) | The origin protocol policy to apply to your origin. One of http-only, https-only, or match-viewer | `string` | `"match-viewer"` | no |
 | <a name="input_origin_read_timeout"></a> [origin\_read\_timeout](#input\_origin\_read\_timeout) | The Custom Read timeout, in seconds. By default, AWS enforces a limit of 60. But you can request an increase. | `number` | `60` | no |
 | <a name="input_origin_request_policy_id"></a> [origin\_request\_policy\_id](#input\_origin\_request\_policy\_id) | ID of the origin request policy attached to the cache behavior | `string` | `null` | no |
-| <a name="input_origin_shield_enabled"></a> [origin\_shield\_enabled](#input\_origin\_shield\_enabled) | Whether to use CloudFront Origin Shield | `bool` | `false` | no |
-| <a name="input_origin_shield_region"></a> [origin\_shield\_region](#input\_origin\_shield\_region) | The AWS Region for the Origin Shield | `string` | `"us-east-1"` | no |
+| <a name="input_origin_shield"></a> [origin\_shield](#input\_origin\_shield) | The CloudFront Origin Shield settings | <pre>object({<br>    enabled = bool<br>    region  = string<br>  })</pre> | `null` | no |
 | <a name="input_origin_ssl_protocols"></a> [origin\_ssl\_protocols](#input\_origin\_ssl\_protocols) | The SSL/TLS protocols that you want CloudFront to use when communicating with your origin over HTTPS | `list(string)` | <pre>[<br>  "TLSv1",<br>  "TLSv1.1",<br>  "TLSv1.2"<br>]</pre> | no |
 | <a name="input_parent_zone_id"></a> [parent\_zone\_id](#input\_parent\_zone\_id) | ID of the hosted zone to contain this record (or specify `parent_zone_name`) | `string` | `""` | no |
 | <a name="input_parent_zone_name"></a> [parent\_zone\_name](#input\_parent\_zone\_name) | Name of the hosted zone to contain this record (or specify `parent_zone_id`) | `string` | `""` | no |

--- a/README.md
+++ b/README.md
@@ -273,7 +273,6 @@ Like this project? Please give it a ★ on [our GitHub](https://github.com/cloud
 Are you using this project or any of our other projects? Consider [leaving a testimonial][testimonial]. =)
 
 
-
 ## Related Projects
 
 Check out these related projects.
@@ -283,6 +282,8 @@ Check out these related projects.
 - [terraform-aws-cloudtrail](https://github.com/cloudposse/terraform-aws-cloudtrail) - Terraform module to provision an AWS CloudTrail and an encrypted S3 bucket with versioning to store CloudTrail logs
 - [terraform-aws-s3-website](https://github.com/cloudposse/terraform-aws-s3-website) - Terraform module to provision S3-backed websites
 - [terraform-root-modules/aws/docs](https://github.com/cloudposse/terraform-root-modules/tree/master/aws/docs) - Reference implementation combining `terraform-aws-s3-website` with `terraform-aws-cdn`
+
+
 
 ## Help
 

--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ Like this project? Please give it a ★ on [our GitHub](https://github.com/cloud
 Are you using this project or any of our other projects? Consider [leaving a testimonial][testimonial]. =)
 
 
+
 ## Related Projects
 
 Check out these related projects.
@@ -283,8 +284,6 @@ Check out these related projects.
 - [terraform-aws-cloudtrail](https://github.com/cloudposse/terraform-aws-cloudtrail) - Terraform module to provision an AWS CloudTrail and an encrypted S3 bucket with versioning to store CloudTrail logs
 - [terraform-aws-s3-website](https://github.com/cloudposse/terraform-aws-s3-website) - Terraform module to provision S3-backed websites
 - [terraform-root-modules/aws/docs](https://github.com/cloudposse/terraform-root-modules/tree/master/aws/docs) - Reference implementation combining `terraform-aws-s3-website` with `terraform-aws-cdn`
-
-
 
 ## Help
 

--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ Like this project? Please give it a ★ on [our GitHub](https://github.com/cloud
 Are you using this project or any of our other projects? Consider [leaving a testimonial][testimonial]. =)
 
 
+
 ## Related Projects
 
 Check out these related projects.
@@ -282,8 +283,6 @@ Check out these related projects.
 - [terraform-aws-cloudtrail](https://github.com/cloudposse/terraform-aws-cloudtrail) - Terraform module to provision an AWS CloudTrail and an encrypted S3 bucket with versioning to store CloudTrail logs
 - [terraform-aws-s3-website](https://github.com/cloudposse/terraform-aws-s3-website) - Terraform module to provision S3-backed websites
 - [terraform-root-modules/aws/docs](https://github.com/cloudposse/terraform-root-modules/tree/master/aws/docs) - Reference implementation combining `terraform-aws-s3-website` with `terraform-aws-cdn`
-
-
 
 ## Help
 

--- a/README.md
+++ b/README.md
@@ -233,8 +233,8 @@ Available targets:
 | <a name="input_origin_protocol_policy"></a> [origin\_protocol\_policy](#input\_origin\_protocol\_policy) | The origin protocol policy to apply to your origin. One of http-only, https-only, or match-viewer | `string` | `"match-viewer"` | no |
 | <a name="input_origin_read_timeout"></a> [origin\_read\_timeout](#input\_origin\_read\_timeout) | The Custom Read timeout, in seconds. By default, AWS enforces a limit of 60. But you can request an increase. | `number` | `60` | no |
 | <a name="input_origin_request_policy_id"></a> [origin\_request\_policy\_id](#input\_origin\_request\_policy\_id) | ID of the origin request policy attached to the cache behavior | `string` | `null` | no |
-| <a name="input_origin_shield_enabled"></a> [origin\_shield\_enabled](#input\_origin\_shield\_enabled) | Use the CloudFront Origin Shield | `bool` | `false` | no |
-| <a name="input_origin_shield_region"></a> [origin\_shield\_region](#input\_origin\_shield\_region) | The AWS Region for the Origin Shield. Example: us-east-1 | `string` | `"us-east-1"` | no |
+| <a name="input_origin_shield_enabled"></a> [origin\_shield\_enabled](#input\_origin\_shield\_enabled) | Whether to use CloudFront Origin Shield | `bool` | `false` | no |
+| <a name="input_origin_shield_region"></a> [origin\_shield\_region](#input\_origin\_shield\_region) | The AWS Region for the Origin Shield | `string` | `"us-east-1"` | no |
 | <a name="input_origin_ssl_protocols"></a> [origin\_ssl\_protocols](#input\_origin\_ssl\_protocols) | The SSL/TLS protocols that you want CloudFront to use when communicating with your origin over HTTPS | `list(string)` | <pre>[<br>  "TLSv1",<br>  "TLSv1.1",<br>  "TLSv1.2"<br>]</pre> | no |
 | <a name="input_parent_zone_id"></a> [parent\_zone\_id](#input\_parent\_zone\_id) | ID of the hosted zone to contain this record (or specify `parent_zone_name`) | `string` | `""` | no |
 | <a name="input_parent_zone_name"></a> [parent\_zone\_name](#input\_parent\_zone\_name) | Name of the hosted zone to contain this record (or specify `parent_zone_id`) | `string` | `""` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -89,8 +89,7 @@
 | <a name="input_origin_protocol_policy"></a> [origin\_protocol\_policy](#input\_origin\_protocol\_policy) | The origin protocol policy to apply to your origin. One of http-only, https-only, or match-viewer | `string` | `"match-viewer"` | no |
 | <a name="input_origin_read_timeout"></a> [origin\_read\_timeout](#input\_origin\_read\_timeout) | The Custom Read timeout, in seconds. By default, AWS enforces a limit of 60. But you can request an increase. | `number` | `60` | no |
 | <a name="input_origin_request_policy_id"></a> [origin\_request\_policy\_id](#input\_origin\_request\_policy\_id) | ID of the origin request policy attached to the cache behavior | `string` | `null` | no |
-| <a name="input_origin_shield_enabled"></a> [origin\_shield\_enabled](#input\_origin\_shield\_enabled) | Whether to use CloudFront Origin Shield | `bool` | `false` | no |
-| <a name="input_origin_shield_region"></a> [origin\_shield\_region](#input\_origin\_shield\_region) | The AWS Region for the Origin Shield | `string` | `"us-east-1"` | no |
+| <a name="input_origin_shield"></a> [origin\_shield](#input\_origin\_shield) | The CloudFront Origin Shield settings | <pre>object({<br>    enabled = bool<br>    region  = string<br>  })</pre> | `null` | no |
 | <a name="input_origin_ssl_protocols"></a> [origin\_ssl\_protocols](#input\_origin\_ssl\_protocols) | The SSL/TLS protocols that you want CloudFront to use when communicating with your origin over HTTPS | `list(string)` | <pre>[<br>  "TLSv1",<br>  "TLSv1.1",<br>  "TLSv1.2"<br>]</pre> | no |
 | <a name="input_parent_zone_id"></a> [parent\_zone\_id](#input\_parent\_zone\_id) | ID of the hosted zone to contain this record (or specify `parent_zone_name`) | `string` | `""` | no |
 | <a name="input_parent_zone_name"></a> [parent\_zone\_name](#input\_parent\_zone\_name) | Name of the hosted zone to contain this record (or specify `parent_zone_id`) | `string` | `""` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -89,8 +89,8 @@
 | <a name="input_origin_protocol_policy"></a> [origin\_protocol\_policy](#input\_origin\_protocol\_policy) | The origin protocol policy to apply to your origin. One of http-only, https-only, or match-viewer | `string` | `"match-viewer"` | no |
 | <a name="input_origin_read_timeout"></a> [origin\_read\_timeout](#input\_origin\_read\_timeout) | The Custom Read timeout, in seconds. By default, AWS enforces a limit of 60. But you can request an increase. | `number` | `60` | no |
 | <a name="input_origin_request_policy_id"></a> [origin\_request\_policy\_id](#input\_origin\_request\_policy\_id) | ID of the origin request policy attached to the cache behavior | `string` | `null` | no |
-| <a name="input_origin_shield_enabled"></a> [origin\_shield\_enabled](#input\_origin\_shield\_enabled) | Use the CloudFront Origin Shield | `bool` | `false` | no |
-| <a name="input_origin_shield_region"></a> [origin\_shield\_region](#input\_origin\_shield\_region) | The AWS Region for the Origin Shield. Example: us-east-1 | `string` | `"us-east-1"` | no |
+| <a name="input_origin_shield_enabled"></a> [origin\_shield\_enabled](#input\_origin\_shield\_enabled) | Whether to use CloudFront Origin Shield | `bool` | `false` | no |
+| <a name="input_origin_shield_region"></a> [origin\_shield\_region](#input\_origin\_shield\_region) | The AWS Region for the Origin Shield | `string` | `"us-east-1"` | no |
 | <a name="input_origin_ssl_protocols"></a> [origin\_ssl\_protocols](#input\_origin\_ssl\_protocols) | The SSL/TLS protocols that you want CloudFront to use when communicating with your origin over HTTPS | `list(string)` | <pre>[<br>  "TLSv1",<br>  "TLSv1.1",<br>  "TLSv1.2"<br>]</pre> | no |
 | <a name="input_parent_zone_id"></a> [parent\_zone\_id](#input\_parent\_zone\_id) | ID of the hosted zone to contain this record (or specify `parent_zone_name`) | `string` | `""` | no |
 | <a name="input_parent_zone_name"></a> [parent\_zone\_name](#input\_parent\_zone\_name) | Name of the hosted zone to contain this record (or specify `parent_zone_id`) | `string` | `""` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -89,6 +89,8 @@
 | <a name="input_origin_protocol_policy"></a> [origin\_protocol\_policy](#input\_origin\_protocol\_policy) | The origin protocol policy to apply to your origin. One of http-only, https-only, or match-viewer | `string` | `"match-viewer"` | no |
 | <a name="input_origin_read_timeout"></a> [origin\_read\_timeout](#input\_origin\_read\_timeout) | The Custom Read timeout, in seconds. By default, AWS enforces a limit of 60. But you can request an increase. | `number` | `60` | no |
 | <a name="input_origin_request_policy_id"></a> [origin\_request\_policy\_id](#input\_origin\_request\_policy\_id) | ID of the origin request policy attached to the cache behavior | `string` | `null` | no |
+| <a name="input_origin_shield_enabled"></a> [origin\_shield\_enabled](#input\_origin\_shield\_enabled) | Use the CloudFront Origin Shield | `bool` | `false` | no |
+| <a name="input_origin_shield_region"></a> [origin\_shield\_region](#input\_origin\_shield\_region) | The AWS Region for the Origin Shield. Example: us-east-1 | `string` | `"us-east-1"` | no |
 | <a name="input_origin_ssl_protocols"></a> [origin\_ssl\_protocols](#input\_origin\_ssl\_protocols) | The SSL/TLS protocols that you want CloudFront to use when communicating with your origin over HTTPS | `list(string)` | <pre>[<br>  "TLSv1",<br>  "TLSv1.1",<br>  "TLSv1.2"<br>]</pre> | no |
 | <a name="input_parent_zone_id"></a> [parent\_zone\_id](#input\_parent\_zone\_id) | ID of the hosted zone to contain this record (or specify `parent_zone_name`) | `string` | `""` | no |
 | <a name="input_parent_zone_name"></a> [parent\_zone\_name](#input\_parent\_zone\_name) | Name of the hosted zone to contain this record (or specify `parent_zone_id`) | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -72,6 +72,14 @@ resource "aws_cloudfront_distribution" "default" {
       origin_read_timeout      = var.origin_read_timeout
     }
 
+    dynamic "origin_shield" {
+      for_each = var.origin_shield_enabled ? ["true"] : []
+      content {
+        enabled              = true
+        origin_shield_region = var.origin_shield_region
+      }
+    }
+
     dynamic "custom_header" {
       for_each = var.custom_header
       content {

--- a/main.tf
+++ b/main.tf
@@ -73,12 +73,9 @@ resource "aws_cloudfront_distribution" "default" {
       origin_read_timeout      = var.origin_read_timeout
     }
 
-    dynamic "origin_shield" {
-      for_each = var.origin_shield_enabled ? ["true"] : []
-      content {
-        enabled              = true
-        origin_shield_region = var.origin_shield_region
-      }
+    origin_shield {
+      enabled              = var.origin_shield_enabled
+      origin_shield_region = var.origin_shield_region
     }
 
     dynamic "custom_header" {

--- a/main.tf
+++ b/main.tf
@@ -29,6 +29,7 @@ module "logs" {
 }
 
 resource "aws_cloudfront_distribution" "default" {
+  #bridgecrew:skip=BC_AWS_GENERAL_27:Skipping `Ensure CloudFront distribution has WAF enabled` because AWS WAF is indeed configurable and is managed via `var.web_acl_id`.
   count = module.this.enabled ? 1 : 0
 
   enabled             = var.distribution_enabled

--- a/main.tf
+++ b/main.tf
@@ -73,9 +73,12 @@ resource "aws_cloudfront_distribution" "default" {
       origin_read_timeout      = var.origin_read_timeout
     }
 
-    origin_shield {
-      enabled              = var.origin_shield_enabled
-      origin_shield_region = var.origin_shield_region
+    dynamic "origin_shield" {
+      for_each = var.origin_shield ? ["true"] : []
+      content {
+        enabled              = var.origin_shield.enabled
+        origin_shield_region = var.origin_shield.region
+      }
     }
 
     dynamic "custom_header" {

--- a/main.tf
+++ b/main.tf
@@ -74,7 +74,7 @@ resource "aws_cloudfront_distribution" "default" {
     }
 
     dynamic "origin_shield" {
-      for_each = var.origin_shield ? ["true"] : []
+      for_each = var.origin_shield != null ? ["true"] : []
       content {
         enabled              = var.origin_shield.enabled
         origin_shield_region = var.origin_shield.region

--- a/variables.tf
+++ b/variables.tf
@@ -91,7 +91,7 @@ variable "origin_shield_enabled" {
 
 variable "origin_shield_region" {
   type        = string
-  description = "The AWS Region for the Origin Shield. Example: us-east-1"
+  description = "The AWS Region for the Origin Shield"
   default     = "us-east-1"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -83,6 +83,18 @@ variable "origin_protocol_policy" {
   default     = "match-viewer"
 }
 
+variable "origin_shield_enabled" {
+  type        = bool
+  description = "Use the CloudFront Origin Shield"
+  default     = false
+}
+
+variable "origin_shield_region" {
+  type        = string
+  description = "The AWS Region for the Origin Shield. Example: us-east-1"
+  default     = "us-east-1"
+}
+
 variable "origin_ssl_protocols" {
   description = "The SSL/TLS protocols that you want CloudFront to use when communicating with your origin over HTTPS"
   type        = list(string)

--- a/variables.tf
+++ b/variables.tf
@@ -83,16 +83,13 @@ variable "origin_protocol_policy" {
   default     = "match-viewer"
 }
 
-variable "origin_shield_enabled" {
-  type        = bool
-  description = "Whether to use CloudFront Origin Shield"
-  default     = false
-}
-
-variable "origin_shield_region" {
-  type        = string
-  description = "The AWS Region for the Origin Shield"
-  default     = "us-east-1"
+variable "origin_shield" {
+  type = object({
+    enabled = bool
+    region  = string
+  })
+  description = "The CloudFront Origin Shield settings"
+  default     = null
 }
 
 variable "origin_ssl_protocols" {

--- a/variables.tf
+++ b/variables.tf
@@ -85,7 +85,7 @@ variable "origin_protocol_policy" {
 
 variable "origin_shield_enabled" {
   type        = bool
-  description = "Use the CloudFront Origin Shield"
+  description = "Whether to use CloudFront Origin Shield"
   default     = false
 }
 


### PR DESCRIPTION
## what
* Add variables to enable the Origin Shield for the CloudFront distribution

## why
* Using Origin Shield can help reduce the load on your origin.

## references
* https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#origin_shield
