### PR TITLE
Dont send ssl_support_method for default certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyright
 
-Copyright © 2017-2021 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2022 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 

--- a/main.tf
+++ b/main.tf
@@ -127,7 +127,7 @@ resource "aws_cloudfront_distribution" "default" {
 
   viewer_certificate {
     acm_certificate_arn            = var.acm_certificate_arn
-    ssl_support_method             = "sni-only"
+    ssl_support_method             = var.acm_certificate_arn == "" ? null : "sni-only"
     minimum_protocol_version       = var.viewer_minimum_protocol_version
     cloudfront_default_certificate = var.acm_certificate_arn == "" ? true : false
   }


### PR DESCRIPTION
## what
* Don't send ssl_support_method when using cloudfront_default_certificate

## why
* It's only required if you specify acm_certificate_arn or iam_certificate_id
* Sending it will cause Terraform to try to update CF on every deploy
```
  ~ viewer_certificate {
      + ssl_support_method             = "sni-only"
        # (2 unchanged attributes hidden)
    }
    # (5 unchanged blocks hidden)
```    
