### PR TITLE
Upgrade S3 Log Storage module to latest version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -14,8 +14,8 @@ resource "aws_cloudfront_origin_access_identity" "default" {
 }
 
 module "logs" {
-  source  = "cloudposse/s3-log-storage/aws"
-  version = "1.1.0"
+  source  = "git@github.com:salesimpact/terraform-aws-s3-log-storage.git?ref=79e050aaedfa9576be1067a3e2d6ec9ac0a8fb6a"
+  # version = "1.1.0"
 
   enabled                  = module.this.enabled && var.logging_enabled && length(var.log_bucket_fqdn) == 0
   attributes               = compact(concat(module.this.attributes, ["origin", "logs"]))

--- a/main.tf
+++ b/main.tf
@@ -274,6 +274,11 @@ resource "aws_cloudfront_distribution" "default" {
   }
 
   tags = module.this.tags
+
+  depends_on = [
+    # Wait until Logs bucket is fully created
+    module.logs
+  ]
 }
 
 module "dns" {

--- a/main.tf
+++ b/main.tf
@@ -33,10 +33,10 @@ module "logs" {
       noncurrent_days = 90
     }
 
-    noncurrent_version_transition = {
+    noncurrent_version_transition = [{
       noncurrent_days = 30
       storage_class   = "GLACIER"
-    }
+    }]
 
     expiration = {
       days = var.log_expiration_days

--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,10 @@ module "logs" {
   attributes               = compact(concat(module.this.attributes, ["origin", "logs"]))
 
   lifecycle_configuration_rules = [{
-    prefix = var.log_prefix
+    id                                     = module.this.id
+    enabled                                = true
+    prefix                                 = var.log_prefix
+    abort_incomplete_multipart_upload_days = 5
 
     noncurrent_version_expiration = {
       noncurrent_days = 90

--- a/main.tf
+++ b/main.tf
@@ -21,10 +21,13 @@ module "logs" {
   attributes               = compact(concat(module.this.attributes, ["origin", "logs"]))
 
   lifecycle_configuration_rules = [{
-    id                                     = module.this.id
-    enabled                                = true
-    prefix                                 = var.log_prefix
+    id      = module.this.id
+    enabled = true
+    prefix  = var.log_prefix
+
     abort_incomplete_multipart_upload_days = 5
+
+    filter_and = null
 
     noncurrent_version_expiration = {
       noncurrent_days = 90


### PR DESCRIPTION
## what
* upgrades `module.logs` to the latest S3 Log Storage module
* the lifecycle configuration block currently has some hardcoded values that were specified following the their respective values using the old S3 Log Storage module, which were automatically set by the module itself (not via inputs)

## why
* closes #96

## references
N/A

