### PR TITLE
bump s3 logs module - fixes S3 ACL issues

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -15,7 +15,7 @@ resource "aws_cloudfront_origin_access_identity" "default" {
 
 module "logs" {
   source  = "cloudposse/s3-log-storage/aws"
-  version = "0.26.0"
+  version = "1.4.0"
 
   enabled                  = module.this.enabled && var.logging_enabled && length(var.log_bucket_fqdn) == 0
   attributes               = compact(concat(module.this.attributes, ["origin", "logs"]))


### PR DESCRIPTION
## what

Bumps the ```cloudposse/s3-log-storage/aws``` to latest version.

## why

Fixes this issue:
https://github.com/cloudposse/terraform-aws-cloudfront-cdn/issues/96
