### PR TITLE
fix: Avoid phantom resource changes in the plan

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -144,7 +144,7 @@ resource "aws_cloudfront_distribution" "default" {
   viewer_certificate {
     acm_certificate_arn            = var.acm_certificate_arn
     ssl_support_method             = var.acm_certificate_arn == "" ? null : "sni-only"
-    minimum_protocol_version       = var.viewer_minimum_protocol_version
+    minimum_protocol_version       = length(var.aliases) == 0 ? "TLSv1" : var.viewer_minimum_protocol_version
     cloudfront_default_certificate = var.acm_certificate_arn == "" ? true : false
   }
 

--- a/main.tf
+++ b/main.tf
@@ -199,9 +199,10 @@ resource "aws_cloudfront_distribution" "default" {
     }
 
     viewer_protocol_policy = var.viewer_protocol_policy
-    default_ttl            = var.default_ttl
-    min_ttl                = var.min_ttl
-    max_ttl                = var.max_ttl
+    # Only set TTL values when no cache policy is specified
+    default_ttl = try(coalesce(var.cache_policy_id), null) == null ? var.default_ttl : 0
+    min_ttl     = try(coalesce(var.cache_policy_id), null) == null ? var.min_ttl : 0
+    max_ttl     = try(coalesce(var.cache_policy_id), null) == null ? var.max_ttl : 0
   }
 
   dynamic "ordered_cache_behavior" {
@@ -240,9 +241,10 @@ resource "aws_cloudfront_distribution" "default" {
       }
 
       viewer_protocol_policy = ordered_cache_behavior.value.viewer_protocol_policy
-      default_ttl            = ordered_cache_behavior.value.default_ttl
-      min_ttl                = ordered_cache_behavior.value.min_ttl
-      max_ttl                = ordered_cache_behavior.value.max_ttl
+      # Only set TTL values when no cache policy is specified
+      default_ttl = try(coalesce(ordered_cache_behavior.value.cache_policy_id), null) == null ? ordered_cache_behavior.value.default_ttl : 0
+      min_ttl     = try(coalesce(ordered_cache_behavior.value.cache_policy_id), null) == null ? ordered_cache_behavior.value.min_ttl : 0
+      max_ttl     = try(coalesce(ordered_cache_behavior.value.cache_policy_id), null) == null ? ordered_cache_behavior.value.max_ttl : 0
 
       dynamic "lambda_function_association" {
         for_each = ordered_cache_behavior.value.lambda_function_association


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

1. Zero all `*_ttl` params when custom cache policy is specified (TTLs included in the policy take precedence)
2. Use `TLSv1` minimum viewer policy for alias-less distribution

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

Certain parameter combinations may lead to phantom changes in the plan. This PR aligns some arguments with AWS's default values that aren't explicitly stated in the documentation.

```tf
#
# Slightly modified version of examples/complete/main.tf
#

provider "aws" {
  region = var.region
}

resource "aws_cloudfront_cache_policy" "default" {
  name        = "DefaultCachePolicy"
  default_ttl = 180
  max_ttl     = 3600
  min_ttl     = 1

  parameters_in_cache_key_and_forwarded_to_origin {
    cookies_config {
      cookie_behavior = "none"
    }

    headers_config {
      header_behavior = "none"
    }

    query_strings_config {
      query_string_behavior = "none"
    }
  }
}

module "cdn" {
  # source = "../../"
  source  = "cloudposse/cloudfront-cdn/aws"
  version = "1.2.0"

  aliases            = var.aliases
  origin_domain_name = var.origin_domain_name
  parent_zone_name   = var.parent_zone_name
  logging_enabled    = false

  cache_policy_id = aws_cloudfront_cache_policy.default.id

  context = module.this.context
}
```

No matter how many times you apply the above, the plan always produces the following (the `min_ttl` does not show up, as it's set to `0` by default):

```console
Terraform will perform the following actions:

  # module.cdn.aws_cloudfront_distribution.default[0] will be updated in-place
  ~ resource "aws_cloudfront_distribution" "default" {
        id                              = "E1NE1WD4E24L7"
        tags                            = {
            "Name"      = "eg-test-cdn"
            "Namespace" = "eg"
            "Stage"     = "test"
        }
        # (23 unchanged attributes hidden)

      ~ default_cache_behavior {
          ~ default_ttl                = 0 -> 60
          ~ max_ttl                    = 0 -> 31536000
            # (14 unchanged attributes hidden)

            # (1 unchanged block hidden)
        }

      ~ viewer_certificate {
          ~ minimum_protocol_version       = "TLSv1" -> "TLSv1.2_2021"
            # (4 unchanged attributes hidden)
        }

        # (2 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

When a local module is referenced (`source = "../../"`), then the subsequent apply works as expected:

```console
No changes. Your infrastructure matches the configuration.
```

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
