### PR TITLE
feat: Add `response_completion_timeout` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,14 +101,14 @@ aws acm request-certificate --domain-name example.com --subject-alternative-name
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.13.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.13.0 |
 
 ## Modules
 
@@ -142,7 +142,7 @@ aws acm request-certificate --domain-name example.com --subject-alternative-name
 | <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br/>See description of individual variables for details.<br/>Leave string and numeric variables as `null` to use default value.<br/>Individual variable settings (non-null) override settings in context object,<br/>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br/>  "additional_tag_map": {},<br/>  "attributes": [],<br/>  "delimiter": null,<br/>  "descriptor_formats": {},<br/>  "enabled": true,<br/>  "environment": null,<br/>  "id_length_limit": null,<br/>  "label_key_case": null,<br/>  "label_order": [],<br/>  "label_value_case": null,<br/>  "labels_as_tags": [<br/>    "unset"<br/>  ],<br/>  "name": null,<br/>  "namespace": null,<br/>  "regex_replace_chars": null,<br/>  "stage": null,<br/>  "tags": {},<br/>  "tenant": null<br/>}</pre> | no |
 | <a name="input_custom_error_response"></a> [custom\_error\_response](#input\_custom\_error\_response) | List of one or more custom error response element maps | <pre>list(object({<br/>    error_caching_min_ttl = optional(string, null)<br/>    error_code            = string<br/>    response_code         = optional(string, null)<br/>    response_page_path    = optional(string, null)<br/>  }))</pre> | `[]` | no |
 | <a name="input_custom_header"></a> [custom\_header](#input\_custom\_header) | List of one or more custom headers passed to the origin | <pre>list(object({<br/>    name  = string<br/>    value = string<br/>  }))</pre> | `[]` | no |
-| <a name="input_custom_origins"></a> [custom\_origins](#input\_custom\_origins) | One or more custom origins for this distribution (multiples allowed). See documentation for configuration options description https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution.html#origin-arguments | <pre>list(object({<br/>    domain_name              = string<br/>    origin_id                = string<br/>    origin_path              = optional(string, "")<br/>    origin_access_control_id = optional(string, null)<br/>    custom_headers = optional(list(object({<br/>      name  = string<br/>      value = string<br/>    })), [])<br/>    custom_origin_config = optional(object({<br/>      http_port                = optional(number, 80)<br/>      https_port               = optional(number, 443)<br/>      origin_protocol_policy   = optional(string, "match-viewer")<br/>      origin_ssl_protocols     = optional(list(string), ["TLSv1", "TLSv1.1", "TLSv1.2"])<br/>      origin_keepalive_timeout = optional(number, 5)<br/>      origin_read_timeout      = optional(number, 30)<br/>    }), null)<br/>    s3_origin_config = optional(object({<br/>      origin_access_identity = string<br/>    }), null)<br/>    origin_shield = optional(object({<br/>      enabled = optional(bool, false)<br/>      region  = optional(string, null)<br/>    }), null)<br/>  }))</pre> | `[]` | no |
+| <a name="input_custom_origins"></a> [custom\_origins](#input\_custom\_origins) | One or more custom origins for this distribution (multiples allowed). See documentation for configuration options description https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution.html#origin-arguments | <pre>list(object({<br/>    domain_name                        = string<br/>    origin_id                          = string<br/>    origin_path                        = optional(string, "")<br/>    origin_access_control_id           = optional(string, null)<br/>    origin_response_completion_timeout = optional(number, 0)<br/>    custom_headers = optional(list(object({<br/>      name  = string<br/>      value = string<br/>    })), [])<br/>    custom_origin_config = optional(object({<br/>      http_port                = optional(number, 80)<br/>      https_port               = optional(number, 443)<br/>      origin_protocol_policy   = optional(string, "match-viewer")<br/>      origin_ssl_protocols     = optional(list(string), ["TLSv1", "TLSv1.1", "TLSv1.2"])<br/>      origin_keepalive_timeout = optional(number, 5)<br/>      origin_read_timeout      = optional(number, 30)<br/>    }), null)<br/>    s3_origin_config = optional(object({<br/>      origin_access_identity = string<br/>    }), null)<br/>    origin_shield = optional(object({<br/>      enabled = optional(bool, false)<br/>      region  = optional(string, null)<br/>    }), null)<br/>  }))</pre> | `[]` | no |
 | <a name="input_default_root_object"></a> [default\_root\_object](#input\_default\_root\_object) | Object that CloudFront return when requests the root URL | `string` | `"index.html"` | no |
 | <a name="input_default_ttl"></a> [default\_ttl](#input\_default\_ttl) | Default amount of time (in seconds) that an object is in a CloudFront cache | `number` | `60` | no |
 | <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between ID elements.<br/>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
@@ -190,6 +190,7 @@ aws acm request-certificate --domain-name example.com --subject-alternative-name
 | <a name="input_origin_protocol_policy"></a> [origin\_protocol\_policy](#input\_origin\_protocol\_policy) | The origin protocol policy to apply to your origin. One of http-only, https-only, or match-viewer | `string` | `"match-viewer"` | no |
 | <a name="input_origin_read_timeout"></a> [origin\_read\_timeout](#input\_origin\_read\_timeout) | The Custom Read timeout, in seconds. By default, AWS enforces a limit of 60. But you can request an increase. | `number` | `30` | no |
 | <a name="input_origin_request_policy_id"></a> [origin\_request\_policy\_id](#input\_origin\_request\_policy\_id) | ID of the origin request policy attached to the cache behavior | `string` | `null` | no |
+| <a name="input_origin_response_completion_timeout"></a> [origin\_response\_completion\_timeout](#input\_origin\_response\_completion\_timeout) | Time (in seconds) that a request from CloudFront to the origin can stay open and wait for a response. Must be integer greater than or equal to the value of origin\_read\_timeout. If omitted or explicitly set to 0, no maximum value is enforced. | `number` | `0` | no |
 | <a name="input_origin_shield"></a> [origin\_shield](#input\_origin\_shield) | The CloudFront Origin Shield settings | <pre>object({<br/>    enabled = optional(bool, false)<br/>    region  = optional(string, null)<br/>  })</pre> | `null` | no |
 | <a name="input_origin_ssl_protocols"></a> [origin\_ssl\_protocols](#input\_origin\_ssl\_protocols) | The SSL/TLS protocols that you want CloudFront to use when communicating with your origin over HTTPS | `list(string)` | <pre>[<br/>  "TLSv1",<br/>  "TLSv1.1",<br/>  "TLSv1.2"<br/>]</pre> | no |
 | <a name="input_origin_type"></a> [origin\_type](#input\_origin\_type) | The type of origin configuration to use. Valid values are 'custom' or 's3'. | `string` | `"custom"` | no |
@@ -387,7 +388,7 @@ All other trademarks referenced herein are the property of their respective owne
 
 
 ---
-Copyright © 2017-2025 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2026 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 <a href="https://cloudposse.com/readme/footer/link?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-cloudfront-cdn&utm_content=readme_footer_link"><img alt="README footer" src="https://cloudposse.com/readme/footer/img"/></a>

--- a/main.tf
+++ b/main.tf
@@ -75,10 +75,11 @@ resource "aws_cloudfront_distribution" "default" {
   }
 
   origin {
-    domain_name              = var.origin_domain_name
-    origin_id                = module.this.id
-    origin_path              = var.origin_path
-    origin_access_control_id = var.origin_type == "s3" ? var.origin_access_control_id : null
+    domain_name                 = var.origin_domain_name
+    origin_id                   = module.this.id
+    origin_path                 = var.origin_path
+    origin_access_control_id    = var.origin_type == "s3" ? var.origin_access_control_id : null
+    response_completion_timeout = var.response_completion_timeout
 
     dynamic "custom_origin_config" {
       for_each = var.origin_type == "custom" ? [1] : []
@@ -124,10 +125,11 @@ resource "aws_cloudfront_distribution" "default" {
   dynamic "origin" {
     for_each = var.custom_origins
     content {
-      domain_name              = origin.value.domain_name
-      origin_id                = origin.value.origin_id
-      origin_path              = origin.value.origin_path
-      origin_access_control_id = origin.value.origin_access_control_id
+      domain_name                 = origin.value.domain_name
+      origin_id                   = origin.value.origin_id
+      origin_path                 = origin.value.origin_path
+      origin_access_control_id    = origin.value.origin_access_control_id
+      response_completion_timeout = origin.value.response_completion_timeout
 
       dynamic "custom_header" {
         for_each = origin.value.custom_headers

--- a/variables.tf
+++ b/variables.tf
@@ -117,6 +117,12 @@ variable "origin_read_timeout" {
   default     = 30
 }
 
+variable "response_completion_timeout" {
+  type        = number
+  description = "Time (in seconds) that a request from CloudFront to the origin can stay open and wait for a response. Must be integer greater than or equal to the value of origin_read_timeout. If omitted or explicitly set to 0, no maximum value is enforced."
+  default     = 0
+}
+
 variable "compress" {
   type        = bool
   description = "Whether you want CloudFront to automatically compress content for web requests that include Accept-Encoding: gzip in the request header (default: false)"
@@ -361,10 +367,11 @@ DESCRIPTION
 
 variable "custom_origins" {
   type = list(object({
-    domain_name              = string
-    origin_id                = string
-    origin_path              = optional(string, "")
-    origin_access_control_id = optional(string, null)
+    domain_name                 = string
+    origin_id                   = string
+    origin_path                 = optional(string, "")
+    origin_access_control_id    = optional(string, null)
+    response_completion_timeout = optional(number, 0)
     custom_headers = optional(list(object({
       name  = string
       value = string

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.9.0"
+      version = ">= 6.13.0"
     }
     local = {
       source  = "hashicorp/local"


### PR DESCRIPTION
## what

- Add support for `response_completion_timeout` argument (announced by AWS in July 2025 and implemented in the [6.13.0](https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#6130-september-11-2025) version of the AWS provider)
- Bump the minimum provider version to `>= 6.13.0` (it was incorrect anyway, e.g. `grpc_config` block needs [5.83.0](https://github.com/hashicorp/terraform-provider-aws/blob/release/5.x/CHANGELOG.md#5830-january--9-2025) or newer)

## why

Allows configuring [`response_completion_timeout`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#response_completion_timeout-1) for CloudFront origins.

## references

- https://aws.amazon.com/about-aws/whats-new/2025/07/amazon-cloudfront-origin-response-timeout-controls/
- https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#6130-september-11-2025
- corresponding PR: https://github.com/cloudposse/terraform-aws-cloudfront-s3-cdn/pull/369